### PR TITLE
fix: /terms /privacy /refund 직접 200 반환 (Paddle 검증봇 대응)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,6 @@ import { routing } from "./src/i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  // Match all pathnames except Next.js internals and static files
-  matcher: ["/((?!api|_next|_vercel|og-image|.*\\..*).*)"],
+  // Match all pathnames except Next.js internals, static files, and legal pages (served via rewrites)
+  matcher: ["/((?!api|_next|_vercel|og-image|terms|privacy|refund|.*\\..*).*)"],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,13 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
   },
+  async rewrites() {
+    return [
+      { source: "/terms", destination: "/en/terms" },
+      { source: "/privacy", destination: "/en/privacy" },
+      { source: "/refund", destination: "/en/refund" },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- next.config.ts에 rewrite 추가: /terms, /privacy, /refund → /en/* 내부 라우팅 (URL 변경 없이 200 반환)
- middleware.ts matcher에서 법적 페이지 3개 제외: next-intl이 307 redirect 하지 않도록 우회

## 문제
- 기존: /terms → 307 → /en/terms (Paddle 검증봇이 307을 따라가지 않아 검증 실패)
- 해결: /terms가 직접 200 반환

## Test plan
- [ ] curl -s -o /dev/null -w "%{http_code}" "https://ai-driven-architect.com/terms" → 200
- [ ] curl -s -o /dev/null -w "%{http_code}" "https://ai-driven-architect.com/privacy" → 200
- [ ] curl -s -o /dev/null -w "%{http_code}" "https://ai-driven-architect.com/refund" → 200
- [ ] 기존 /en/terms, /ko/terms, /ja/terms 정상 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)