### PR TITLE
feat: CRO optimization — sticky CTA, urgency, bundle upsell

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -202,9 +202,14 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
             <span className="inline-block bg-gold/10 border border-gold/20 text-gold text-xs font-semibold px-4 py-1.5 rounded-full tracking-wide uppercase">
               6 World-Class Frameworks + AI
             </span>
-            <span className="text-text-muted text-xs">
-              Used by 500+ entrepreneurs and marketers worldwide
-            </span>
+            <div className="flex items-center gap-2 text-xs text-text-muted">
+              <span className="inline-flex items-center gap-1">
+                <span className="w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse" />
+                Used by 500+ entrepreneurs worldwide
+              </span>
+              <span className="text-white/20">·</span>
+              <span>7-day money-back guarantee</span>
+            </div>
           </div>
 
           <h1 className="text-4xl md:text-6xl font-bold leading-tight mb-6">
@@ -219,9 +224,9 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
             No more &ldquo;how do I apply this?&rdquo; Just results.
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-6">
             <BuyButton href={bundleUrl} className="text-lg px-10 py-4 animate-pulse-subtle">
-              Get Complete Bundle — ${bundle.price}
+              Get All 6 Books — ${bundle.price}
             </BuyButton>
             <Link
               href="/products"
@@ -230,8 +235,11 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
               View Individual Books — $17 each
             </Link>
           </div>
+          <p className="text-center text-xs text-text-muted mb-8">
+            Instant PDF download. No account required. 7-day money-back guarantee.
+          </p>
 
-          <div className="flex flex-wrap justify-center gap-3 text-xs text-text-muted">
+          <div className="flex flex-wrap justify-center gap-3 text-xs text-text-muted" aria-label="Purchase benefits">
             <span className="flex items-center gap-1.5 bg-white/5 px-3 py-1.5 rounded-full">
               <svg className="w-3.5 h-3.5 text-gold" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -557,13 +565,16 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
                 </li>
               </ul>
               <BuyButton href={bundleUrl} className="w-full text-lg py-4 animate-pulse-subtle">
-                Get the Complete Bundle — ${bundle.price}
+                Get All 6 Books — ${bundle.price}
               </BuyButton>
+              <p className="text-xs text-text-muted mt-3">
+                Instant PDF download · 7-day money-back guarantee · No questions asked
+              </p>
             </div>
           </div>
 
           <p className="text-center text-text-muted text-xs mt-8">
-            Source books retail for ~$175+. Strategy consulting to apply them: $2,000-$10,000+.
+            Source books retail for ~$175+. Strategy consulting to apply them: $2,000–$10,000+.
           </p>
         </div>
       </section>

--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function ProductPage({ params }: Props) {
                   paddleSuccessUrl={`${siteUrl}/thank-you?product=${encodeURIComponent(book.title)}`}
                   className="text-lg px-8 py-4"
                 >
-                  Buy {book.title} — $17
+                  Get {book.title} — $17
                 </BuyButton>
                 <BuyButton
                   href={bundleUrl}
@@ -178,12 +178,12 @@ export default async function ProductPage({ params }: Props) {
                   variant="secondary"
                   className="text-sm py-2"
                 >
-                  Or get all 6 for $47
+                  Get All 6 Books — $47
                 </BuyButton>
               </div>
 
               <p className="text-xs text-text-muted mt-3">
-                Immediate PDF download · 7-day money-back guarantee
+                Instant PDF download · 7-day money-back guarantee · No questions asked
               </p>
             </div>
 
@@ -244,11 +244,17 @@ export default async function ProductPage({ params }: Props) {
         {/* CTA */}
         <section className="max-w-4xl mx-auto px-4">
           <div className="bg-surface/60 border border-gold/20 rounded-2xl p-8 text-center card-glow">
+            <div className="inline-block bg-gold/10 border border-gold/20 text-gold text-xs font-semibold px-3 py-1 rounded-full mb-4 uppercase tracking-wide">
+              Instant PDF Download
+            </div>
             <h2 className="text-2xl font-bold mb-2">
               Ready to execute {book.framework} with AI?
             </h2>
-            <p className="text-text-secondary mb-6">
-              Immediate PDF download. Works with Claude, ChatGPT, and Gemini.
+            <p className="text-text-secondary mb-2">
+              Works with Claude, ChatGPT, and Gemini. Start your first AI session in under 1 hour.
+            </p>
+            <p className="text-sm text-gold/80 mb-6">
+              500+ entrepreneurs are already using these frameworks.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <BuyButton
@@ -257,7 +263,7 @@ export default async function ProductPage({ params }: Props) {
                 paddleSuccessUrl={`${siteUrl}/thank-you?product=${encodeURIComponent(book.title)}`}
                 className="text-lg px-8 py-4"
               >
-                Buy {book.title} — $17
+                Get {book.title} — $17
               </BuyButton>
               <BuyButton
                 href={bundleUrl}
@@ -268,9 +274,16 @@ export default async function ProductPage({ params }: Props) {
                 Get All 6 Books — $47
               </BuyButton>
             </div>
-            <p className="text-xs text-text-muted mt-4">
-              7-day money-back guarantee · No questions asked
-            </p>
+            <div className="flex items-center justify-center gap-4 mt-4 text-xs text-text-muted">
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5 text-gold" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                7-day money-back guarantee
+              </span>
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5 text-gold" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" /></svg>
+                No account required
+              </span>
+            </div>
           </div>
         </section>
 

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -84,7 +84,7 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
               Six AI-powered systems for marketing, branding, traffic, copywriting, product launches, and content — one price.
             </p>
           </div>
-          <div className="flex flex-col items-center md:items-end gap-2 shrink-0">
+          <div className="flex flex-col items-start md:items-end gap-2 shrink-0">
             <div className="flex items-center gap-3">
               <span className="text-text-secondary line-through">${bundle.originalPrice}</span>
               <span className="bg-red-500 text-white text-xs font-bold px-2 py-0.5 rounded">SAVE ${bundle.originalPrice - bundle.price}</span>
@@ -96,8 +96,9 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
               paddleSuccessUrl={`${siteUrl}/thank-you?product=Complete+Bundle`}
               className="text-sm px-6 py-2.5"
             >
-              Get All 6 Books
+              Get All 6 Books — ${bundle.price}
             </BuyButton>
+            <p className="text-xs text-text-muted">Instant download · 7-day guarantee</p>
           </div>
         </div>
       </div>

--- a/src/components/StickyMobileCTA.tsx
+++ b/src/components/StickyMobileCTA.tsx
@@ -13,7 +13,7 @@ export default function StickyMobileCTA({
 
   useEffect(() => {
     function handleScroll() {
-      setVisible(window.scrollY > 600);
+      setVisible(window.scrollY > 500);
     }
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
@@ -24,13 +24,16 @@ export default function StickyMobileCTA({
   const isDisabled = bundleUrl === "#" || !bundleUrl;
 
   return (
-    <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-navy-dark/95 backdrop-blur-md border-t border-white/10 px-4 py-3 flex items-center justify-between gap-3">
-      <div className="text-sm">
-        <span className="text-text-primary font-semibold">Complete Bundle</span>
-        <span className="text-gold font-bold ml-2">${bundlePrice}</span>
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-navy-dark/97 backdrop-blur-md border-t border-gold/20 px-4 py-3 flex items-center justify-between gap-3 shadow-lg">
+      <div>
+        <div className="text-sm font-bold text-text-primary">
+          Complete Bundle
+          <span className="text-gold ml-2">${bundlePrice}</span>
+        </div>
+        <div className="text-xs text-text-muted">All 6 books · 7-day guarantee</div>
       </div>
       {isDisabled ? (
-        <span className="bg-gold/20 text-gold px-4 py-2 rounded-lg text-xs font-bold">
+        <span className="bg-gold/20 text-gold px-4 py-2.5 rounded-lg text-xs font-bold">
           Coming Soon
         </span>
       ) : (
@@ -38,9 +41,9 @@ export default function StickyMobileCTA({
           href={bundleUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="bg-gold text-navy-dark px-4 py-2 rounded-lg text-xs font-bold hover:bg-gold-light transition-colors"
+          className="bg-gold text-navy-dark px-5 py-2.5 rounded-lg text-sm font-bold hover:bg-gold-light transition-colors whitespace-nowrap"
         >
-          Get Bundle
+          Get Bundle — ${bundlePrice}
         </a>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **StickyMobileCTA**: 데스크톱+모바일 모두 표시, 스크롤 트리거 600→500px 단축, guarantee 문구 추가
- **Landing Hero**: live 인디케이터 배지 + 7-day guarantee 미리보기, CTA 문구 'Get All 6 Books'로 강화
- **Landing Bundle CTA**: guarantee 문구 인라인 추가 (구매 불안 제거)
- **Product page `/products/[slug]`**: CTA 문구 Buy→Get 전환, urgency 배지 + social proof 500+ 추가, guarantee 아이콘 표시
- **Products list page**: Bundle 버튼에 가격 명시 + guarantee 문구 추가

## CRO 개선 포인트

| 항목 | 이전 | 이후 |
|------|------|------|
| Sticky CTA | 모바일 only | 전체 디바이스 |
| Hero social proof | 배지만 | live indicator + guarantee |
| Product CTA | "Buy ... — $17" | "Get ... — $17" |
| Bundle upsell | "Or get all 6 for $47" | "Get All 6 Books — $47" |
| Guarantee 표시 | 텍스트만 | 아이콘 + 텍스트 강조 |

## Test plan

- [ ] 랜딩 페이지 Hero urgency 배지 확인
- [ ] 스크롤 500px 이후 Sticky CTA 표시 확인 (데스크톱+모바일)
- [ ] /products/[slug] CTA 문구 및 guarantee 아이콘 확인
- [ ] /products 리스트 Bundle CTA 가격 표시 확인
- [ ] 빌드 오류 없음 확인 (로컬 build 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)