### PR TITLE
refactor: CTA 목적 분리 — 각 페이지 단일 목적 원칙 적용

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -157,10 +157,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         </div>
       </article>
       <div className="mt-16 pt-8 border-t border-white/10 text-center">
-        <p className="text-text-secondary mb-4">Ready to apply AI to your business?</p>
-        <Link href="/bundle" className="inline-block bg-gold text-navy-dark px-6 py-3 rounded-lg hover:bg-gold-light transition-colors font-bold">
-          Get the AI Architect Series →
-        </Link>
+        <p className="text-text-secondary mb-2">Get weekly AI business frameworks — every Friday.</p>
+        <p className="text-xs text-text-muted">500+ entrepreneurs subscribed · No spam · Unsubscribe anytime</p>
       </div>
 
       {/* Related Posts */}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -115,10 +115,8 @@ export default async function BlogPage({ params }: { params: Promise<{ locale: s
           ))}
         </div>
         <div className="mt-16 pt-8 border-t border-white/10 text-center">
-          <p className="text-text-secondary mb-4">Ready to apply these AI frameworks to your business?</p>
-          <Link href="/bundle" className="inline-block bg-gold text-navy-dark px-6 py-3 rounded-lg hover:bg-gold-light transition-colors font-bold">
-            Get the Complete AI Architect Bundle — $47 →
-          </Link>
+          <p className="text-text-secondary mb-2">Get weekly AI business frameworks delivered to your inbox.</p>
+          <p className="text-xs text-text-muted">500+ entrepreneurs subscribed · Every Friday · No spam</p>
         </div>
       </main>
     </>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { books, bundle, getBundleUrl, getProductUrl } from "@/lib/products";
 import BuyButton from "@/components/BuyButton";
 import FaqAccordion from "@/components/FaqAccordion";
-import EmailCapture from "@/components/EmailCapture";
 import StickyMobileCTA from "@/components/StickyMobileCTA";
 import { setRequestLocale } from "next-intl/server";
 
@@ -587,36 +586,6 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         </div>
       </section>
 
-      {/* Email Capture — Free Framework Sample */}
-      <section className="py-20 pb-32 md:pb-20">
-        <div className="max-w-2xl mx-auto px-4 text-center">
-          <div className="inline-block bg-gold/10 border border-gold/20 text-gold text-xs font-semibold px-4 py-1.5 rounded-full mb-4 uppercase tracking-wide">
-            500+ entrepreneurs already subscribed
-          </div>
-          <h2 className="text-2xl md:text-3xl font-bold mb-4">Get the Free AI Framework Sample</h2>
-          <p className="text-text-secondary mb-3">
-            Get a free preview of the AI Architect framework + 3 ready-to-use system prompts — plus weekly AI business insights every Friday.
-          </p>
-          <div className="flex flex-wrap justify-center gap-4 text-xs text-text-muted mb-8">
-            <span className="flex items-center gap-1.5">
-              <span className="text-gold">&#10003;</span> Cut 50%+ strategy time with AI
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="text-gold">&#10003;</span> Real results from 500+ users
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="text-gold">&#10003;</span> Every Friday — no fluff
-            </span>
-          </div>
-          <EmailCapture
-            buttonText="Send Me the Free Framework"
-            className="max-w-lg mx-auto"
-          />
-          <p className="text-text-muted text-xs mt-4">
-            No spam. Unsubscribe anytime.
-          </p>
-        </div>
-      </section>
       <StickyMobileCTA bundlePrice={bundle.price} bundleUrl={bundleUrl} />
     </>
   );

--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { usePathname } from "next/navigation";
 
 declare global {
   interface Window {
@@ -14,6 +15,8 @@ const SUBSCRIBED_KEY = "ai_architect_subscribed";
 const DISMISS_DAYS = 14;
 
 export default function ExitIntentPopup() {
+  const pathname = usePathname();
+  const isBlogPage = pathname?.includes("/blog");
   const [visible, setVisible] = useState(false);
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -26,8 +29,9 @@ export default function ExitIntentPopup() {
     } catch {}
   }, []);
 
-  // Exit intent detection (desktop only)
+  // Exit intent detection (desktop only, blog pages only)
   useEffect(() => {
+    if (!isBlogPage) return;
     if (typeof window !== "undefined" && window.innerWidth < 768) return;
     try {
       if (localStorage.getItem(SUBSCRIBED_KEY)) return;

--- a/src/components/ScrollSubscribeBanner.tsx
+++ b/src/components/ScrollSubscribeBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { usePathname } from "next/navigation";
 
 declare global {
   interface Window {
@@ -13,6 +14,8 @@ const DISMISS_KEY = "ai_architect_scroll_dismissed";
 const SUBSCRIBED_KEY = "ai_architect_subscribed";
 
 export default function ScrollSubscribeBanner() {
+  const pathname = usePathname();
+  const isBlogPage = pathname?.includes("/blog");
   const [visible, setVisible] = useState(false);
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -25,6 +28,7 @@ export default function ScrollSubscribeBanner() {
   }, []);
 
   useEffect(() => {
+    if (!isBlogPage) return;
     try {
       if (localStorage.getItem(SUBSCRIBED_KEY)) return;
       if (sessionStorage.getItem(DISMISS_KEY)) return;


### PR DESCRIPTION
## Summary
- ExitIntentPopup / ScrollSubscribeBanner를 블로그 페이지(/blog*)에서만 활성화
- 홈(/): 인라인 EmailCapture 구독 섹션 제거 (목적=구매 단일화)
- /blog, /blog/[slug]: 하단 Buy CTA 링크 제거 (목적=구독 단일화)

## 변경 원칙
각 페이지 = 1개 목적 (CEO 지침 적용)
- 홈: 번들 구매 CTA만 (StickyMobileCTA 유지)
- /products, /products/[slug]: 제품 구매 CTA만 (변경 없음, 이미 정상)
- /bundle: 번들 구매 CTA만 (변경 없음, 이미 정상)
- /blog, /blog/[slug]: 구독 CTA만 (exit-intent + scroll-trigger 블로그 전용)
- /about: 보조 구매 링크 1개 (변경 없음, 이미 정상)

## Test plan
- [ ] 홈 접속 → ScrollSubscribeBanner/ExitIntentPopup 미노출 확인
- [ ] /blog 접속 후 50% 스크롤 → ScrollSubscribeBanner 노출 확인
- [ ] /blog/[slug] 접속 후 마우스 상단 이탈 → ExitIntentPopup 노출 확인
- [ ] /products, /bundle 접속 → 구독 팝업 미노출 확인
- [ ] 빌드 성공 확인 (로컬 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)