### PR TITLE
feat: sitemap legal pages + IndexNow 104 URLs

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -40,6 +40,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "bundle", changeFrequency: "weekly", priority: 0.9 },
     { path: "about", changeFrequency: "monthly", priority: 0.6 },
     { path: "blog", changeFrequency: "weekly", priority: 0.8 },
+    { path: "terms", changeFrequency: "yearly", priority: 0.3 },
+    { path: "privacy", changeFrequency: "yearly", priority: 0.3 },
+    { path: "refund", changeFrequency: "yearly", priority: 0.3 },
   ];
 
   const productRoutes: RouteEntry[] = books.map((book) => ({


### PR DESCRIPTION
## Summary
- Add /terms, /privacy, /refund to sitemap.xml (were missing from 3 legal pages)
- IndexNow 104 URLs submitted to Bing (200), Yandex (202), Naver (200)
- All 26 routes x 4 language variants (canonical + en/ko/ja)

## Changes
- `src/app/sitemap.ts`: Added terms, privacy, refund to staticRoutes

## Verification
- `npm run build` passed
- IndexNow API responses all successful
- sitemap now covers: 8 static + 6 products + 12 blog = 26 routes x 4 = 104 URLs

## Test plan
- [ ] Verify /sitemap.xml includes /terms, /privacy, /refund URLs
- [ ] Verify legal pages accessible in all 3 languages

Generated with [Claude Code](https://claude.com/claude-code)