### PR TITLE
fix: SEO critical issues — homepage metadata + /pricing redirect

### DIFF
--- a/content/blog/ai-architect-vs-ai-user.md
+++ b/content/blog/ai-architect-vs-ai-user.md
@@ -1,5 +1,6 @@
 ---
 title: "AI Architect vs. AI User: Why the Gap Is Growing in 2026"
+description: "Using AI tools and architecting AI systems are fundamentally different skills. Learn why the gap between AI users and AI architects is accelerating in 2026 and how to bridge it."
 date: "2026-02-28"
 excerpt: "Using AI tools and architecting AI systems are fundamentally different skills. Here's why the gap between them is accelerating."
 ---

--- a/content/blog/ai-email-automation-for-solopreneurs.md
+++ b/content/blog/ai-email-automation-for-solopreneurs.md
@@ -1,5 +1,6 @@
 ---
 title: "AI Email Automation for Solopreneurs: The System That Converts While You Sleep"
+description: "How to build an AI-powered email automation system that nurtures leads, handles objections, and drives sales for solopreneurs — without writing every email yourself."
 date: "2026-02-28"
 excerpt: "How to build an AI-powered email system that nurtures leads, handles objections, and drives sales — without writing every email yourself."
 ---

--- a/content/blog/building-ai-content-pipeline.md
+++ b/content/blog/building-ai-content-pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: "Building an AI Content Pipeline: From Idea to Published in 45 Minutes"
+description: "A step-by-step guide to building a content production pipeline that runs on AI. Go from idea to published article in 45 minutes without sacrificing quality or authenticity."
 date: "2026-02-28"
 excerpt: "A step-by-step guide to building a content production system that runs on AI — without sacrificing quality or authenticity."
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,12 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
   },
+  async redirects() {
+    return [
+      { source: "/pricing", destination: "/en/products", permanent: true },
+      { source: "/:locale/pricing", destination: "/:locale/products", permanent: true },
+    ];
+  },
   async rewrites() {
     return [
       { source: "/terms", destination: "/en/terms" },

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -7,55 +7,81 @@ import FaqAccordion from "@/components/FaqAccordion";
 import StickyMobileCTA from "@/components/StickyMobileCTA";
 import { setRequestLocale } from "next-intl/server";
 
-export const metadata: Metadata = {
-  title: "AI Architect Series — You've Read the Books. Now Let AI Execute the Frameworks.",
-  description:
-    "6 AI-powered PDF guides turn Russell Brunson, Jeff Walker, Jim Edwards, and Nicolas Cole's frameworks into executable systems you can run today. Bundle: $47. Individual books: $17.",
-  keywords: [
-    "AI business framework",
-    "Russell Brunson AI",
-    "DotCom Secrets AI system",
-    "Jeff Walker Product Launch Formula AI",
-    "Jim Edwards Copywriting Secrets AI",
-    "Nicolas Cole AI writing",
-    "AI sales funnel automation",
-    "business PDF guide",
-    "AI marketing system",
-    "online business AI",
-  ],
-  openGraph: {
+const homeMeta: Record<string, { title: string; description: string; ogDescription: string; twitterDescription: string }> = {
+  en: {
     title: "AI Architect Series — You've Read the Books. Now Let AI Execute the Frameworks.",
-    description:
-      "6 AI-powered PDF guides turn world-class business frameworks into executable systems. Bundle: $47.",
-    url: "https://ai-driven-architect.com",
-    type: "website",
-    locale: "en_US",
-    siteName: "AI Architect Series",
-    images: [
-      {
-        url: "https://ai-driven-architect.com/og-image",
-        width: 1200,
-        height: 630,
-        alt: "AI Architect Series — 6 AI-Powered Business Frameworks",
-      },
-    ],
+    description: "6 AI-powered PDF guides turn Russell Brunson, Jeff Walker, Jim Edwards, and Nicolas Cole's frameworks into executable systems you can run today. Bundle: $47. Individual books: $17.",
+    ogDescription: "6 AI-powered PDF guides turn world-class business frameworks into executable systems. Bundle: $47.",
+    twitterDescription: "6 PDF guides that turn Russell Brunson, Jeff Walker, Jim Edwards frameworks into AI-powered systems. Bundle $47.",
   },
-  twitter: {
-    card: "summary_large_image",
-    title: "AI Architect Series — Let AI Execute the Frameworks",
-    description:
-      "6 PDF guides that turn Russell Brunson, Jeff Walker, Jim Edwards frameworks into AI-powered systems. Bundle $47.",
-    images: ["https://ai-driven-architect.com/og-image"],
+  ko: {
+    title: "AI Architect Series — 세계적 비즈니스 프레임워크를 AI로 실행하세요.",
+    description: "Russell Brunson, Jeff Walker, Jim Edwards, Nicolas Cole의 프레임워크를 AI 시스템으로 전환하는 6권의 PDF 가이드. 번들: $47.",
+    ogDescription: "세계적 비즈니스 프레임워크를 AI로 자동화하는 6권의 실행 가이드. 번들: $47.",
+    twitterDescription: "Russell Brunson, Jeff Walker 프레임워크를 AI 시스템으로 전환. 번들 $47.",
   },
-  alternates: {
-    canonical: "https://ai-driven-architect.com",
-    languages: {
-      en: "https://ai-driven-architect.com",
-      ko: "https://ai-driven-architect.com/ko",
-      ja: "https://ai-driven-architect.com/ja",
-    },
+  ja: {
+    title: "AI Architect Series — ビジネスフレームワークをAIで実行しよう。",
+    description: "Russell Brunson、Jeff Walker、Jim Edwards、Nicolas Coleのフレームワークを実行可能なAIシステムに変換する6冊のPDFガイド。バンドル: $47。",
+    ogDescription: "世界クラスのビジネスフレームワークをAIで自動化する6冊の実行ガイド。バンドル: $47。",
+    twitterDescription: "Russell Brunson、Jeff WalkerのフレームワークをAIシステムに変換。バンドル $47。",
   },
 };
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
+  const meta = homeMeta[locale] ?? homeMeta.en;
+  const canonicalUrl = locale === "en" ? siteUrl : `${siteUrl}/${locale}`;
+  const ogLocale = locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US";
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    keywords: [
+      "AI business framework",
+      "Russell Brunson AI",
+      "DotCom Secrets AI system",
+      "Jeff Walker Product Launch Formula AI",
+      "Jim Edwards Copywriting Secrets AI",
+      "Nicolas Cole AI writing",
+      "AI sales funnel automation",
+      "business PDF guide",
+      "AI marketing system",
+      "online business AI",
+    ],
+    openGraph: {
+      title: meta.title,
+      description: meta.ogDescription,
+      url: canonicalUrl,
+      type: "website",
+      locale: ogLocale,
+      siteName: "AI Architect Series",
+      images: [
+        {
+          url: `${siteUrl}/og-image`,
+          width: 1200,
+          height: 630,
+          alt: "AI Architect Series — 6 AI-Powered Business Frameworks",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: meta.title,
+      description: meta.twitterDescription,
+      images: [`${siteUrl}/og-image`],
+    },
+    alternates: {
+      canonical: canonicalUrl,
+      languages: {
+        en: siteUrl,
+        ko: `${siteUrl}/ko`,
+        ja: `${siteUrl}/ja`,
+      },
+    },
+  };
+}
 
 const results = [
   { metric: "500+", label: "Entrepreneurs & marketers using these frameworks" },


### PR DESCRIPTION
## Summary
- **Critical 1**: Homepage `export const metadata` converted to `generateMetadata` for locale-aware canonical URLs, OG tags, and meta descriptions (en/ko/ja)
- **Critical 2**: `/pricing` → `/products` permanent redirect added (both root and locale-prefixed)
- **Warning**: Added missing `description` frontmatter to 3 blog posts (ai-architect-vs-ai-user, ai-email-automation-for-solopreneurs, building-ai-content-pipeline)

## Test plan
- [ ] Verify /en homepage renders title, description, OG tags in page source
- [ ] Verify /ko and /ja homepages have locale-specific metadata
- [ ] Verify /pricing redirects to /en/products (301)
- [ ] Verify /en/pricing redirects to /en/products (301)
- [ ] Verify 3 blog posts show description in meta tags

## Build
- `npm run build` passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)