### PR TITLE
feat: SEO deep audit — blog img alt fallback

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -153,7 +153,22 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           <p className="text-lg text-text-secondary">{post.description}</p>
         </header>
         <div className="prose prose-invert prose-gold max-w-none">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              // eslint-disable-next-line @next/next/no-img-element
+              img: ({ src, alt, ...props }) => {
+                const srcStr = typeof src === 'string' ? src : '';
+                const fallbackAlt = srcStr ? srcStr.split('/').pop()?.replace(/[-_]/g, ' ').replace(/\.\w+$/, '') || 'article image' : 'article image';
+                return (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={srcStr} alt={alt || fallbackAlt} loading="lazy" {...props} />
+                );
+              },
+            }}
+          >
+            {post.content}
+          </ReactMarkdown>
         </div>
       </article>
       {/* Product CTA */}


### PR DESCRIPTION
## Summary
- blog/[slug] ReactMarkdown에 img alt fallback 추가
- 빈 alt 또는 누락된 alt 태그에 파일명 기반 자동 alt 텍스트 생성
- 빌드 성공 확인 완료

## Changes
- `src/app/[locale]/blog/[slug]/page.tsx`: img 커스텀 렌더러 추가

## Test plan
- [ ] /blog/[slug] 페이지 렌더링 확인
- [ ] 블로그 포스트 내 이미지 alt 태그 검증 (DevTools)
- [ ] Lighthouse accessibility 점수 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)