### PR TITLE
feat: ai-architect 동적 OG 이미지 생성

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,88 @@
+import { ImageResponse } from "next/og";
+import { getPostBySlug } from "@/lib/blog";
+
+export const alt = "AI Architect Blog";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: { slug: string; locale: string } }) {
+  const post = getPostBySlug(params.slug);
+  const title = post?.title || params.slug.replace(/-/g, " ");
+  const desc = post?.description || "";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px 80px",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "4px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+        <div
+          style={{
+            color: "#e2b714",
+            fontSize: "16px",
+            fontWeight: "700",
+            marginBottom: "20px",
+            letterSpacing: "1px",
+            textTransform: "uppercase",
+          }}
+        >
+          AI ARCHITECT SERIES — BLOG
+        </div>
+        <div
+          style={{
+            fontSize: "44px",
+            fontWeight: "800",
+            color: "#f1f5f9",
+            lineHeight: 1.2,
+            marginBottom: "20px",
+            maxWidth: "900px",
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: "20px",
+            color: "#94a3b8",
+            lineHeight: 1.4,
+            maxWidth: "800px",
+          }}
+        >
+          {desc}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "16px",
+            color: "#e2b714",
+            fontWeight: "600",
+          }}
+        >
+          ai-driven-architect.com
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -39,20 +39,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       url: canonicalUrl,
       locale: locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US",
       siteName: "AI Architect Series",
-      images: [
-        {
-          url: `${siteUrl}/og-image`,
-          width: 1200,
-          height: 630,
-          alt: post.title,
-        },
-      ],
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description: post.description,
-      images: [`${siteUrl}/og-image`],
     },
     alternates: {
       canonical: canonicalUrl,

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -15,7 +15,6 @@ const ExitIntentPopup = dynamic(() => import("@/components/ExitIntentPopup"));
 const ScrollSubscribeBanner = dynamic(() => import("@/components/ScrollSubscribeBanner"));
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
-const OG_IMAGE = `${SITE_URL}/og-image`;
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -47,21 +46,12 @@ export const metadata: Metadata = {
     locale: "en_US",
     siteName: "AI Architect Series",
     url: SITE_URL,
-    images: [
-      {
-        url: OG_IMAGE,
-        width: 1200,
-        height: 630,
-        alt: "AI Architect Series — 6 AI-Powered Business Frameworks",
-      },
-    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "AI Architect Series — 6 World-Class Frameworks, Fully Automated with AI",
     description:
       "Stop reading business books. Start running the frameworks with AI. 6 PDF guides that make DotCom Secrets, PLF, Copywriting Secrets, and more executable today.",
-    images: [OG_IMAGE],
   },
   robots: {
     index: true,

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,107 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "AI Architect Series";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const LOCALE_TITLE: Record<string, string> = {
+  en: "AI Architect Series",
+  ko: "AI 아키텍트 시리즈",
+  ja: "AIアーキテクトシリーズ",
+};
+
+const LOCALE_DESC: Record<string, string> = {
+  en: "6 World-Class Frameworks, Fully Automated with AI",
+  ko: "6가지 세계적 프레임워크, AI로 완전 자동화",
+  ja: "6つの世界クラスフレームワーク、AIで完全自動化",
+};
+
+export default async function Image({ params }: { params: { locale: string } }) {
+  const locale = params.locale || "en";
+  const title = LOCALE_TITLE[locale] || LOCALE_TITLE.en;
+  const desc = LOCALE_DESC[locale] || LOCALE_DESC.en;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "4px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+        <div
+          style={{
+            background: "rgba(226,183,20,0.1)",
+            border: "1px solid rgba(226,183,20,0.3)",
+            color: "#e2b714",
+            fontSize: "14px",
+            fontWeight: "700",
+            padding: "6px 20px",
+            borderRadius: "100px",
+            marginBottom: "24px",
+            letterSpacing: "2px",
+            textTransform: "uppercase",
+          }}
+        >
+          AI ARCHITECT SERIES
+        </div>
+        <div
+          style={{
+            fontSize: "52px",
+            fontWeight: "800",
+            color: "#f1f5f9",
+            textAlign: "center",
+            lineHeight: 1.15,
+            marginBottom: "20px",
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: "24px",
+            fontWeight: "400",
+            color: "#94a3b8",
+            textAlign: "center",
+            maxWidth: "700px",
+            lineHeight: 1.4,
+          }}
+        >
+          {desc}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "16px",
+            color: "#e2b714",
+            fontWeight: "600",
+          }}
+        >
+          ai-driven-architect.com
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
## Summary
- 홈페이지 locale별(en/ko/ja) 동적 OG 이미지 생성
- 블로그 [slug] 동적 OG 이미지 (제목+설명 표시)
- 기존 하드코딩 OG images 메타데이터 제거

## Tech
- next/og ImageResponse
- 1200x630, 브랜드 컬러(다크+골드)

## Test plan
- [x] `npx next build` 성공
- [ ] /en, /ko, /ja 각 locale OG 이미지 렌더링 확인
- [ ] /en/blog/[slug] OG 이미지에 포스트 제목 표시 확인

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>