### PR TITLE
fix: ai-architect Schema.org 구조화 데이터 보강

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -37,14 +37,25 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
   const t = await getTranslations("about");
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
-  const breadcrumbJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "About", item: `${siteUrl}/about` },
-    ],
-  };
+  const aboutPageJsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      name: "About AI Architect Series",
+      url: `${siteUrl}/about`,
+      description: "Bridge the gap between reading and executing proven business frameworks with AI-powered tools.",
+      isPartOf: { "@id": `${siteUrl}/#website` },
+      mainEntity: { "@id": `${siteUrl}/#organization` },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+        { "@type": "ListItem", position: 2, name: "About", item: `${siteUrl}/about` },
+      ],
+    },
+  ];
 
   const approaches = [
     { title: t("approach1Title"), desc: t("approach1Desc") },
@@ -57,7 +68,7 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
     <div className="min-h-screen pt-24 pb-20">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(breadcrumbJsonLd)) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(aboutPageJsonLd)) }}
       />
       <div className="max-w-3xl mx-auto px-4">
         {/* Hero */}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -91,6 +91,11 @@ function buildSiteJsonLd(locale: string, siteUrl: string) {
       name: names[locale] ?? names.en,
       url: locale === "en" ? siteUrl : `${siteUrl}/${locale}`,
       description: descriptions[locale] ?? descriptions.en,
+      potentialAction: {
+        "@type": "SearchAction",
+        target: `${siteUrl}/products/{search_term_string}`,
+        "query-input": "required name=search_term_string",
+      },
     },
     {
       "@context": "https://schema.org",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -154,20 +154,6 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
 
   const dateLocale = locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US";
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    name: "AI Architect Series",
-    url: siteUrl,
-    description:
-      "6 AI-powered PDF guides turn Russell Brunson, Jeff Walker, Jim Edwards, and Nicolas Cole's business frameworks into executable AI systems.",
-    potentialAction: {
-      "@type": "SearchAction",
-      target: `${siteUrl}/products/{search_term_string}`,
-      "query-input": "required name=search_term_string",
-    },
-  };
-
   const faqPageJsonLd = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -201,10 +187,6 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(jsonLd)) }}
-      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(faqPageJsonLd)) }}

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -25,35 +25,49 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
   const bundlePaddlePriceId = getBundlePaddlePriceId();
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: "AI Architect Series — All Books",
-    description: "6 AI-powered PDF guides that turn proven business frameworks into executable AI systems.",
-    numberOfItems: books.length,
-    itemListElement: books.map((book, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      item: {
-        "@type": "Product",
-        name: book.title,
-        description: book.shortDescription,
-        url: `${siteUrl}/products/${book.slug}`,
-        offers: {
-          "@type": "Offer",
-          price: "17",
-          priceCurrency: "USD",
-          availability: "https://schema.org/InStock",
+  function escapeJsonLd(json: string): string {
+    return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+  }
+
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+        { "@type": "ListItem", position: 2, name: "All Books", item: `${siteUrl}/products` },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "AI Architect Series — All Books",
+      description: "6 AI-powered PDF guides that turn proven business frameworks into executable AI systems.",
+      numberOfItems: books.length,
+      itemListElement: books.map((book, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "Product",
+          name: book.title,
+          description: book.shortDescription,
+          url: `${siteUrl}/products/${book.slug}`,
+          offers: {
+            "@type": "Offer",
+            price: "17",
+            priceCurrency: "USD",
+            availability: "https://schema.org/InStock",
+          },
         },
-      },
-    })),
-  };
+      })),
+    },
+  ];
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(jsonLd)) }}
       />
     <div className="min-h-screen pt-24 pb-20">
       {/* Header */}


### PR DESCRIPTION
## Summary
- layout WebSite Schema에 SearchAction 추가
- about 페이지에 AboutPage Schema 추가 (P1)
- products 페이지에 BreadcrumbList 추가 + XSS escaping (P1)
- 홈 page.tsx에서 중복 WebSite Schema 제거 (layout에만 유지)

## Test plan
- [ ] 빌드 성공 확인 (완료)
- [ ] Schema.org 유효성 검증 (Rich Results Test)
- [ ] 중복 WebSite Schema 해소 확인

Generated with Claude Code