### PR TITLE
feat: ai-architect 내부 크로스링크 강화

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -140,6 +140,17 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
           </div>
         </div>
 
+        {/* Blog cross-link */}
+        <div className="mb-16 p-5 bg-white/5 border border-white/10 rounded-xl">
+          <p className="text-sm text-text-secondary mb-1">Latest insights</p>
+          <Link
+            href="/blog"
+            className="text-gold hover:text-gold-light font-medium text-sm transition-colors"
+          >
+            Read our blog for AI business frameworks and strategies →
+          </Link>
+        </div>
+
         {/* CTA */}
         <div className="bg-surface/60 border border-gold/20 rounded-2xl p-8 text-center card-glow">
           <h2 className="text-2xl font-bold mb-3">

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 import { routing } from "@/i18n/routing";
+import { books } from "@/lib/products";
 
 export function generateStaticParams() {
   const posts = getAllPosts();
@@ -69,6 +70,28 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     .filter((p) => p.tags.some((t) => post.tags.includes(t)))
     .slice(0, 3);
   const otherPosts = relatedPosts.length > 0 ? relatedPosts : allPosts.filter((p) => p.slug !== slug).slice(0, 3);
+
+  const TAG_TO_PRODUCT_SLUG: Record<string, string> = {
+    "Russell Brunson": "ai-marketing-architect",
+    "DotCom Secrets": "ai-marketing-architect",
+    "AI funnel": "ai-marketing-architect",
+    "Expert Secrets": "ai-brand-architect",
+    "Jeff Walker": "ai-launch-architect",
+    "Product Launch Formula": "ai-launch-architect",
+    "Jim Edwards": "ai-copywriting-architect",
+    "Copywriting Secrets": "ai-copywriting-architect",
+    "Nicolas Cole": "ai-content-architect",
+    "online writing": "ai-content-architect",
+    "AI marketing": "ai-marketing-architect",
+    "marketing automation": "ai-marketing-architect",
+    "email marketing": "ai-marketing-architect",
+  };
+  const matchedSlugs = new Set<string>();
+  post.tags.forEach((tag) => {
+    const productSlug = TAG_TO_PRODUCT_SLUG[tag];
+    if (productSlug) matchedSlugs.add(productSlug);
+  });
+  const relatedProducts = books.filter((b) => matchedSlugs.has(b.slug)).slice(0, 2);
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
@@ -183,6 +206,27 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           </Link>
         </div>
       </div>
+
+      {relatedProducts.length > 0 && (
+        <div className="mt-6 space-y-3">
+          <p className="text-xs text-text-secondary uppercase tracking-wider">Related in This Topic</p>
+          {relatedProducts.map((book) => (
+            <Link
+              key={book.slug}
+              href={`/products/${book.slug}`}
+              className="block border border-white/10 rounded-xl p-4 hover:border-gold/30 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-2xl">{book.icon}</span>
+                <div>
+                  <p className="font-semibold text-text-primary text-sm">{book.title}</p>
+                  <p className="text-xs text-text-secondary line-clamp-1">{book.tagline}</p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
 
       <div className="mt-8 pt-8 border-t border-white/10 text-center">
         <p className="text-text-secondary mb-2">Get weekly AI business frameworks — every Friday.</p>


### PR DESCRIPTION
## Summary
- /blog/[slug] 상세 페이지에 태그 기반 관련 상품 추천 카드 추가
- /about 페이지에 /blog 크로스링크 추가

## Changes
- blog/[slug]/page.tsx: TAG_TO_PRODUCT_SLUG mapping + related product cards below CTA
- about/page.tsx: blog cross-link section with "Latest insights" label

## Test plan
- [ ] /blog/russell-brunson-ai-framework → AI Marketing Architect 카드 표시
- [ ] /blog/product-launch-formula-ai → AI Launch Architect 카드 표시
- [ ] /about → "Read our blog" 링크 → /blog 이동
- [ ] 빌드 성공 확인

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>