### PR TITLE
seo: ai-architect 법적 페이지 BreadcrumbList 추가

### DIFF
--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -16,12 +16,36 @@ export const metadata: Metadata = {
   },
 };
 
+const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
+  en: { home: "Home", page: "Privacy Policy" },
+  ko: { home: "\uD648", page: "\uAC1C\uC778\uC815\uBCF4\uCC98\uB9AC\uBC29\uCE68" },
+  ja: { home: "\u30DB\u30FC\u30E0", page: "\u30D7\u30E9\u30A4\u30D0\u30B7\u30FC\u30DD\u30EA\u30B7\u30FC" },
+};
+
+function getBreadcrumbJsonLd(locale: string) {
+  const labels = BREADCRUMB_LABELS[locale] || BREADCRUMB_LABELS.en;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: labels.home, item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: labels.page, item: `${SITE_URL}/${locale}/privacy` },
+    ],
+  };
+}
+
 export default async function PrivacyPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   return (
     <div className="min-h-screen pt-24 pb-20">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getBreadcrumbJsonLd(locale)).replace(/</g, "\\u003c"),
+        }}
+      />
       <div className="max-w-3xl mx-auto px-4">
         <div className="mb-10">
           <h1 className="text-4xl font-bold mb-3 gradient-gold">Privacy Policy</h1>

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -16,12 +16,36 @@ export const metadata: Metadata = {
   },
 };
 
+const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
+  en: { home: "Home", page: "Refund Policy" },
+  ko: { home: "\uD648", page: "\uD658\uBD88 \uC815\uCC45" },
+  ja: { home: "\u30DB\u30FC\u30E0", page: "\u8FD4\u91D1\u30DD\u30EA\u30B7\u30FC" },
+};
+
+function getBreadcrumbJsonLd(locale: string) {
+  const labels = BREADCRUMB_LABELS[locale] || BREADCRUMB_LABELS.en;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: labels.home, item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: labels.page, item: `${SITE_URL}/${locale}/refund` },
+    ],
+  };
+}
+
 export default async function RefundPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   return (
     <div className="min-h-screen pt-24 pb-20">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getBreadcrumbJsonLd(locale)).replace(/</g, "\\u003c"),
+        }}
+      />
       <div className="max-w-3xl mx-auto px-4">
         <div className="mb-10">
           <h1 className="text-4xl font-bold mb-3 gradient-gold">Refund Policy</h1>

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -16,12 +16,36 @@ export const metadata: Metadata = {
   },
 };
 
+const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
+  en: { home: "Home", page: "Terms of Service" },
+  ko: { home: "\uD648", page: "\uC774\uC6A9\uC57D\uAD00" },
+  ja: { home: "\u30DB\u30FC\u30E0", page: "\u5229\u7528\u898F\u7D04" },
+};
+
+function getBreadcrumbJsonLd(locale: string) {
+  const labels = BREADCRUMB_LABELS[locale] || BREADCRUMB_LABELS.en;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: labels.home, item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: labels.page, item: `${SITE_URL}/${locale}/terms` },
+    ],
+  };
+}
+
 export default async function TermsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   return (
     <div className="min-h-screen pt-24 pb-20">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(getBreadcrumbJsonLd(locale)).replace(/</g, "\\u003c"),
+        }}
+      />
       <div className="max-w-3xl mx-auto px-4">
         <div className="mb-10">
           <h1 className="text-4xl font-bold mb-3 gradient-gold">Terms of Service</h1>


### PR DESCRIPTION
## Summary
- /[locale]/privacy, /[locale]/terms, /[locale]/refund 페이지에 BreadcrumbList JSON-LD 추가
- 다국어 지원: en/ko/ja locale별 라벨 대응
- JSON-LD XSS escaping 적용

## Test plan
- [x] `npm run build` 성공 확인
- [ ] /en/privacy, /ko/privacy, /ja/privacy 등에서 JSON-LD 확인
- [ ] Rich Results Test 검증

Generated with [Claude Code](https://claude.com/claude-code)