### PR TITLE
fix: pricing EmailCapture overflow

### DIFF
--- a/src/components/EmailCapture.tsx
+++ b/src/components/EmailCapture.tsx
@@ -74,7 +74,7 @@ export default function EmailCapture({
           Exclusive subscriber discounts
         </li>
       </ul>
-      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <div className="absolute opacity-0 -z-10 h-0 overflow-hidden" aria-hidden="true">
           <label htmlFor="ec-website">Website</label>
           <input


### PR DESCRIPTION
## Summary
- pricing 카드 내 EmailCapture 폼이 카드 너비를 초과하는 overflow 버그 수정
- `sm:flex-row` 제거하여 이메일 입력+버튼이 항상 세로(flex-col) 배치되도록 변경

## Test plan
- [ ] 모바일/태블릿/데스크톱에서 pricing 카드 확인
- [ ] COMPLETE BUNDLE 카드의 이메일 폼이 카드 내부에 정상 표시되는지 확인