### PR TITLE
fix: pricing EmailCapture overflow → production

### DIFF
--- a/src/components/EmailCapture.tsx
+++ b/src/components/EmailCapture.tsx
@@ -74,7 +74,7 @@ export default function EmailCapture({
           Exclusive subscriber discounts
         </li>
       </ul>
-      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <div className="absolute opacity-0 -z-10 h-0 overflow-hidden" aria-hidden="true">
           <label htmlFor="ec-website">Website</label>
           <input


### PR DESCRIPTION
## Summary
- pricing 카드 내 EmailCapture 폼 overflow 수정 (CEO 긴급)
- staging 검증 완료 → production 승격

## Changes
- `sm:flex-row` 제거 → 항상 세로 배치(flex-col)로 카드 내부 정상 표시