### PR TITLE
chore: staging→production — exit-intent CTA 전체 페이지 확장 + sitemap+IndexNow fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ PADDLE_API_KEY=pdl_sdbx_your-api-key
 
 # Paddle Webhook Secret (웹훅 서명 검증용)
 # Paddle 대시보드 > Notifications > Webhook에서 발급
-# Webhook 등록 URL: https://ai-native-playbook.com/api/webhooks/paddle
+# Webhook 등록 URL: https://ai-driven-architect.com/api/webhooks/paddle
 # 구독 이벤트: transaction.completed, transaction.payment_failed
 PADDLE_WEBHOOK_SECRET=your-webhook-signing-secret
 
@@ -53,4 +53,4 @@ BREVO_API_KEY=xkeysib-your-brevo-api-key
 # ─────────────────────────────────────────────────────
 # 공통
 # ─────────────────────────────────────────────────────
-NEXT_PUBLIC_SITE_URL=https://ai-native-playbook.com
+NEXT_PUBLIC_SITE_URL=https://ai-driven-architect.com

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,19 @@
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./src/i18n/routing";
+import { NextRequest, NextResponse } from "next/server";
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // /ko 및 /ko/* 경로를 301로 / 에 영구 리다이렉트
+  if (pathname === "/ko" || pathname.startsWith("/ko/")) {
+    return NextResponse.redirect(new URL("/", request.url), 301);
+  }
+
+  return intlMiddleware(request);
+}
 
 export const config = {
   // Match all pathnames except Next.js internals, static files, and legal pages (served via rewrites)

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,8 @@ const nextConfig: NextConfig = {
   images: {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
   async redirects() {
     return [

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -23,7 +23,7 @@ const aboutMeta: Record<string, { title: string; description: string }> = {
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const meta = aboutMeta[locale] ?? aboutMeta.en;
   const canonicalUrl = locale === "en" ? `${siteUrl}/about` : `${siteUrl}/${locale}/about`;
 
@@ -68,7 +68,7 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
 
   const t = await getTranslations("about");
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const aboutPageJsonLd = [
     {
       "@context": "https://schema.org",

--- a/src/app/[locale]/api/indexnow/route.ts
+++ b/src/app/[locale]/api/indexnow/route.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 
 const INDEXNOW_KEY = "aiarchitectglobal2026indexnow";
-const INDEXNOW_HOST = "ai-native-playbook.com";
+const INDEXNOW_HOST = "ai-driven-architect.com";
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
 
 // GET: 모든 블로그 포스트 URL을 IndexNow에 일괄 제출 (en locale 기준)
@@ -27,7 +27,7 @@ export async function GET() {
   const res = await fetch(INDEXNOW_ENDPOINT, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
-    body: JSON.stringify({ host: INDEXNOW_HOST, key: INDEXNOW_KEY, urlList: urls }),
+    body: JSON.stringify({ host: INDEXNOW_HOST, key: INDEXNOW_KEY, keyLocation: `https://ai-driven-architect.com/${INDEXNOW_KEY}.txt`, urlList: urls }),
   });
 
   return NextResponse.json({ submitted: urls.length, status: res.status });

--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -79,7 +79,7 @@ export default async function Image({ params }: { params: { slug: string; locale
             fontWeight: "600",
           }}
         >
-          ai-native-playbook.com
+          ai-driven-architect.com
         </div>
       </div>
     ),

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const post = getPostBySlug(slug);
   if (!post) return {};
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const canonicalUrl = `${siteUrl}/blog/${slug}`;
 
   return {
@@ -92,7 +92,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   });
   const relatedProducts = books.filter((b) => matchedSlugs.has(b.slug)).slice(0, 2);
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   const articleJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 const blogMeta: Record<string, { title: string; description: string; ogDescription: string }> = {
   en: {

--- a/src/app/[locale]/bundle/page.tsx
+++ b/src/app/[locale]/bundle/page.tsx
@@ -26,7 +26,7 @@ const bundleMeta: Record<string, { title: string; description: string; ogDescrip
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const meta = bundleMeta[locale] ?? bundleMeta.en;
   const canonicalUrl = locale === "en" ? `${siteUrl}/bundle` : `${siteUrl}/${locale}/bundle`;
 
@@ -75,7 +75,7 @@ export default async function BundlePage({ params }: { params: Promise<{ locale:
 
   const t = await getTranslations("bundle");
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   const bonusItems = [
     {

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -4,7 +4,7 @@ import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
 import { getBundleUrl } from "@/lib/products";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ import { MetaPixel } from "@/components/MetaPixel";
 const ExitIntentPopup = dynamic(() => import("@/components/ExitIntentPopup"));
 const ScrollSubscribeBanner = dynamic(() => import("@/components/ScrollSubscribeBanner"));
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -198,7 +198,7 @@ export default async function LocaleLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(siteJsonLd)) }}
         />
-        {/* GA4: ai-native-playbook.com — 자비스 자동 삽입 */}
+        {/* GA4: ai-driven-architect.com — 자비스 자동 삽입 */}
         <Script src="https://www.googletagmanager.com/gtag/js?id=G-76C0HSW5LB" strategy="lazyOnload" />
         <Script id="ga4-ai-architect-io" strategy="lazyOnload">
           {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-76C0HSW5LB');`}
@@ -228,9 +228,9 @@ export default async function LocaleLayout({
             </Script>
           </>
         )}
-        <MetaPixel />
       </head>
       <body className="antialiased min-h-screen flex flex-col bg-navy text-text-primary">
+        <MetaPixel />
         <a href="#main-content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[200] focus:rounded-md focus:bg-gold focus:px-4 focus:py-2 focus:text-navy-dark focus:text-sm focus:font-medium">
           Skip to content
         </a>

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -98,7 +98,7 @@ export default async function Image({ params }: { params: { locale: string } }) 
             fontWeight: "600",
           }}
         >
-          ai-native-playbook.com
+          ai-driven-architect.com
         </div>
       </div>
     ),

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -36,7 +36,7 @@ const homeMeta: Record<string, { title: string; description: string; ogDescripti
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const meta = homeMeta[locale] ?? homeMeta.en;
   const canonicalUrl = locale === "en" ? siteUrl : `${siteUrl}/${locale}`;
   const ogLocale = locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US";
@@ -103,7 +103,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
   const tt = await getTranslations("testimonials");
   const tr = await getTranslations("caseStudies");
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   const results = [
     { metric: t("results.metric1"), label: t("results.label1") },

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 export const metadata: Metadata = {
   title: "Privacy Policy — AI Native Playbook Series",
@@ -61,7 +61,7 @@ export default async function PrivacyPage({ params }: { params: Promise<{ locale
             <h2 className="text-xl font-semibold text-text-primary mb-4">1. Introduction</h2>
             <p>
               NEWBIZSOFT (&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;), operating the website{" "}
-              <span className="text-gold">ai-native-playbook.com</span> under the service name <strong className="text-text-primary">AI Native Playbook Series</strong>, is committed to protecting your personal information. This Privacy Policy explains how we collect, use, disclose, and safeguard your data when you visit our website or purchase our products.
+              <span className="text-gold">ai-driven-architect.com</span> under the service name <strong className="text-text-primary">AI Native Playbook Series</strong>, is committed to protecting your personal information. This Privacy Policy explains how we collect, use, disclose, and safeguard your data when you visit our website or purchase our products.
             </p>
           </section>
 
@@ -180,8 +180,8 @@ export default async function PrivacyPage({ params }: { params: Promise<{ locale
             </ul>
             <p className="mt-3">
               To exercise any of these rights, contact us at{" "}
-              <a href="mailto:contact@ai-native-playbook.com" className="text-gold hover:underline">
-                contact@ai-native-playbook.com
+              <a href="mailto:contact@ai-driven-architect.com" className="text-gold hover:underline">
+                contact@ai-driven-architect.com
               </a>. We will respond within 30 days.
             </p>
           </section>
@@ -211,8 +211,8 @@ export default async function PrivacyPage({ params }: { params: Promise<{ locale
             <h2 className="text-xl font-semibold text-text-primary mb-4">11. Contact Us</h2>
             <p>
               For privacy-related questions or to exercise your rights, contact us at:{" "}
-              <a href="mailto:contact@ai-native-playbook.com" className="text-gold hover:underline">
-                contact@ai-native-playbook.com
+              <a href="mailto:contact@ai-driven-architect.com" className="text-gold hover:underline">
+                contact@ai-driven-architect.com
               </a>
             </p>
           </section>

--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const book = getBookBySlug(slug);
   if (!book) return {};
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const canonicalUrl = `${siteUrl}/products/${slug}`;
   return {
     title: `${book.title} — ${book.subtitle}`,
@@ -89,7 +89,7 @@ export default async function ProductPage({ params }: Props) {
     (process.env[book.paddlePriceEnvKey] as string | undefined) ?? undefined;
   const bundlePaddlePriceId = getBundlePaddlePriceId();
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const dateLocale = locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US";
 
   const jsonLd = {

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -23,7 +23,7 @@ const productsMeta: Record<string, { title: string; description: string }> = {
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const meta = productsMeta[locale] ?? productsMeta.en;
   const canonicalUrl = locale === "en" ? `${siteUrl}/products` : `${siteUrl}/${locale}/products`;
 
@@ -58,7 +58,7 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
 
   const bundleUrl = getBundleUrl();
   const bundlePaddlePriceId = getBundlePaddlePriceId();
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   function escapeJsonLd(json: string): string {
     return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 export const metadata: Metadata = {
   title: "Refund Policy — AI Native Playbook Series",
@@ -106,8 +106,8 @@ export default async function RefundPage({ params }: { params: Promise<{ locale:
                   desc: (
                     <>
                       Email us at{" "}
-                      <a href="mailto:contact@ai-native-playbook.com" className="text-gold hover:underline">
-                        contact@ai-native-playbook.com
+                      <a href="mailto:contact@ai-driven-architect.com" className="text-gold hover:underline">
+                        contact@ai-driven-architect.com
                       </a>{" "}
                       with the subject line: <span className="text-text-primary font-mono text-sm bg-surface/60 px-1.5 py-0.5 rounded">Refund Request — [Your Order Number]</span>
                     </>
@@ -161,8 +161,8 @@ export default async function RefundPage({ params }: { params: Promise<{ locale:
             <h2 className="text-xl font-semibold text-text-primary mb-4">6. Contact</h2>
             <p>
               For any questions about our refund policy, please contact us at:{" "}
-              <a href="mailto:contact@ai-native-playbook.com" className="text-gold hover:underline">
-                contact@ai-native-playbook.com
+              <a href="mailto:contact@ai-driven-architect.com" className="text-gold hover:underline">
+                contact@ai-driven-architect.com
               </a>
             </p>
             <p className="mt-3">

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
 export const metadata: Metadata = {
   title: "Terms of Service — AI Native Playbook Series",
@@ -60,7 +60,7 @@ export default async function TermsPage({ params }: { params: Promise<{ locale: 
           <section>
             <h2 className="text-xl font-semibold text-text-primary mb-4">1. Agreement to Terms</h2>
             <p>
-              By purchasing or accessing any product from <strong className="text-text-primary">AI Native Playbook Series</strong>, operated by <strong className="text-text-primary">NEWBIZSOFT</strong> (website: <span className="text-gold">ai-native-playbook.com</span>), you agree to be bound by these Terms of Service. If you do not agree to these terms, do not purchase or use our products.
+              By purchasing or accessing any product from <strong className="text-text-primary">AI Native Playbook Series</strong>, operated by <strong className="text-text-primary">NEWBIZSOFT</strong> (website: <span className="text-gold">ai-driven-architect.com</span>), you agree to be bound by these Terms of Service. If you do not agree to these terms, do not purchase or use our products.
             </p>
           </section>
 
@@ -183,8 +183,8 @@ export default async function TermsPage({ params }: { params: Promise<{ locale: 
             <h2 className="text-xl font-semibold text-text-primary mb-4">11. Contact</h2>
             <p>
               For questions about these Terms of Service, please contact us at:{" "}
-              <a href="mailto:contact@ai-native-playbook.com" className="text-gold hover:underline">
-                contact@ai-native-playbook.com
+              <a href="mailto:contact@ai-driven-architect.com" className="text-gold hover:underline">
+                contact@ai-driven-architect.com
               </a>
             </p>
           </section>

--- a/src/app/[locale]/thank-you/page.tsx
+++ b/src/app/[locale]/thank-you/page.tsx
@@ -96,10 +96,10 @@ export default async function ThankYouPage({
             us:
           </p>
           <a
-            href="mailto:hello@ai-native-playbook.com"
+            href="mailto:hello@ai-driven-architect.com"
             className="text-gold hover:text-gold-light transition-colors font-semibold"
           >
-            hello@ai-native-playbook.com
+            hello@ai-driven-architect.com
           </a>
         </div>
 

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -104,7 +104,7 @@ export async function POST(request: Request) {
             to: [{ email: sanitizedEmail, name: name || sanitizedEmail }],
             sender: { name: "AI Native Playbook", email: "contact@apppro.kr" },
             subject: "Your Free AI Framework Preview + 3 System Prompts",
-            htmlContent: `<div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#1a1a1a;padding:24px"><h1 style="color:#1e3a5f;">Your AI Framework Preview is Ready</h1><p>Thanks for joining the AI Native Playbook community${name ? `, ${name}` : ""}!</p><p>Here's what you get:</p><ul style="line-height:2;"><li><strong>AI Framework Preview</strong> -- Core concepts from 6 world-class frameworks</li><li><strong>3 System Prompts</strong> -- Ready to paste into Claude or ChatGPT</li><li><strong>Early-bird discount</strong> -- When we launch</li></ul><div style="text-align:center;margin:28px 0;"><a href="https://ai-native-playbook.com/products" style="display:inline-block;background:#f59e0b;color:#1a1a1a;padding:14px 32px;border-radius:8px;font-weight:bold;text-decoration:none;">Explore AI Native Playbook Series</a></div><p style="color:#888;font-size:12px;margin-top:32px;border-top:1px solid #eee;padding-top:16px;text-align:center;"><a href="https://ai-native-playbook.com" style="color:#1e3a5f;text-decoration:none;">AI Native Playbook Series</a></p></div>`,
+            htmlContent: `<div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#1a1a1a;padding:24px"><h1 style="color:#1e3a5f;">Your AI Framework Preview is Ready</h1><p>Thanks for joining the AI Native Playbook community${name ? `, ${name}` : ""}!</p><p>Here's what you get:</p><ul style="line-height:2;"><li><strong>AI Framework Preview</strong> -- Core concepts from 6 world-class frameworks</li><li><strong>3 System Prompts</strong> -- Ready to paste into Claude or ChatGPT</li><li><strong>Early-bird discount</strong> -- When we launch</li></ul><div style="text-align:center;margin:28px 0;"><a href="https://ai-driven-architect.com/products" style="display:inline-block;background:#f59e0b;color:#1a1a1a;padding:14px 32px;border-radius:8px;font-weight:bold;text-decoration:none;">Explore AI Native Playbook Series</a></div><p style="color:#888;font-size:12px;margin-top:32px;border-top:1px solid #eee;padding-top:16px;text-align:center;"><a href="https://ai-driven-architect.com" style="color:#1e3a5f;text-decoration:none;">AI Native Playbook Series</a></p></div>`,
           }),
         });
       } catch {
@@ -115,7 +115,7 @@ export async function POST(request: Request) {
       const greeting = name ? `${name}님, 환영합니다!` : "환영합니다!";
       const sender = { name: "AI Native Playbook", email: "contact@apppro.kr" };
       const to = [{ email: sanitizedEmail, name: name || sanitizedEmail }];
-      const brand = { color: "#1e3a5f", url: "https://ai-native-playbook.com" };
+      const brand = { color: "#1e3a5f", url: "https://ai-driven-architect.com" };
       const footer = `<p style="color:#888;font-size:12px;margin-top:32px;border-top:1px solid #eee;padding-top:16px;text-align:center;"><a href="${brand.url}" style="color:${brand.color};text-decoration:none;">AI Native Playbook</a>에서 발송했습니다. <a href="{{ unsubscribe }}" style="color:${brand.color};text-decoration:none;">구독 해지</a></p>`;
 
       const sequence = [

--- a/src/app/api/webhooks/lemonsqueezy/route.ts
+++ b/src/app/api/webhooks/lemonsqueezy/route.ts
@@ -93,7 +93,7 @@ async function sendConfirmationEmail(order: Order): Promise<void> {
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-native-playbook.com",
+        email: "hello@ai-driven-architect.com",
       },
       to: [{ email: order.customerEmail, name: order.customerName }],
       subject: `Your ${order.productName} is ready to download`,
@@ -114,7 +114,7 @@ async function sendConfirmationEmail(order: Order): Promise<void> {
             If you have any issues, reply to this email and we'll help you right away.
           </p>
           <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;" />
-          <p style="color: #999; font-size: 12px;">AI Native Playbook Series | ai-native-playbook.com</p>
+          <p style="color: #999; font-size: 12px;">AI Native Playbook Series | ai-driven-architect.com</p>
         </div>
       `,
     }),

--- a/src/app/api/webhooks/paddle/route.ts
+++ b/src/app/api/webhooks/paddle/route.ts
@@ -117,7 +117,7 @@ async function sendPaddleConfirmationEmail(
   }
 
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   const res = await fetch("https://api.brevo.com/v3/smtp/email", {
     method: "POST",
@@ -128,7 +128,7 @@ async function sendPaddleConfirmationEmail(
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-native-playbook.com",
+        email: "hello@ai-driven-architect.com",
       },
       to: [{ email: order.customerEmail, name: order.customerName }],
       subject: `Your ${order.productName} is ready to download`,
@@ -153,7 +153,7 @@ async function sendPaddleConfirmationEmail(
             If you have any issues, reply to this email and we'll help you right away.
           </p>
           <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;" />
-          <p style="color: #999; font-size: 12px;">AI Native Playbook Series | ai-native-playbook.com</p>
+          <p style="color: #999; font-size: 12px;">AI Native Playbook Series | ai-driven-architect.com</p>
         </div>
       `,
     }),

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/", "/_next/"],
     },
-    sitemap: "https://ai-native-playbook.com/sitemap.xml",
+    sitemap: "https://ai-driven-architect.com/sitemap.xml",
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { books } from "@/lib/products";
 import { getAllPosts } from "@/lib/blog";
 
-const BASE_URL = "https://ai-native-playbook.com";
+const BASE_URL = "https://ai-driven-architect.com";
 
 // 로캘 prefix 없는 영어 canonical URL
 function canonicalUrl(path: string): string {

--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -123,7 +123,7 @@ export default function BuyButton({
       e.preventDefault();
 
       const siteUrl =
-        process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+        process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
       window.Paddle.Checkout.open({
         items: [{ priceId: paddlePriceId!, quantity: 1 }],

--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 declare global {
@@ -16,8 +15,6 @@ const SUBSCRIBED_KEY = "ai_architect_subscribed";
 const DISMISS_DAYS = 14;
 
 export default function ExitIntentPopup() {
-  const pathname = usePathname();
-  const isBlogPage = pathname?.includes("/blog");
   const [visible, setVisible] = useState(false);
   const [email, setEmail] = useState("");
   const [website, setWebsite] = useState("");
@@ -33,7 +30,6 @@ export default function ExitIntentPopup() {
   }, []);
 
   useEffect(() => {
-    if (!isBlogPage) return;
     if (typeof window !== "undefined" && window.innerWidth < 768) return;
     try {
       if (localStorage.getItem(SUBSCRIBED_KEY)) return;

--- a/src/components/ScrollSubscribeBanner.tsx
+++ b/src/components/ScrollSubscribeBanner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 declare global {
@@ -15,8 +14,6 @@ const DISMISS_KEY = "ai_architect_scroll_dismissed";
 const SUBSCRIBED_KEY = "ai_architect_subscribed";
 
 export default function ScrollSubscribeBanner() {
-  const pathname = usePathname();
-  const isBlogPage = pathname?.includes("/blog");
   const [visible, setVisible] = useState(false);
   const [email, setEmail] = useState("");
   const [website, setWebsite] = useState("");
@@ -31,7 +28,6 @@ export default function ScrollSubscribeBanner() {
   }, []);
 
   useEffect(() => {
-    if (!isBlogPage) return;
     try {
       if (localStorage.getItem(SUBSCRIBED_KEY)) return;
       if (sessionStorage.getItem(DISMISS_KEY)) return;

--- a/src/lib/paddle.ts
+++ b/src/lib/paddle.ts
@@ -55,7 +55,7 @@ export async function createPaddleTransaction(
   }
 
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
   const body: Record<string, unknown> = {
     items: options.items.map((item) => ({

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -313,7 +313,7 @@ export function getBundleUrl(): string {
   const base = process.env.NEXT_PUBLIC_LS_BUNDLE_URL ?? "#";
   if (base === "#") return "#";
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const redirect = encodeURIComponent(
     `${siteUrl}/thank-you?product=Complete+Bundle`
   );
@@ -327,7 +327,7 @@ export function getProductUrl(envKey: string): string {
   if (base === "#") return "#";
   const book = books.find((b) => b.envKey === envKey);
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com";
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
   const productName = encodeURIComponent(book?.title ?? "AI Native Playbook");
   const redirect = encodeURIComponent(
     `${siteUrl}/thank-you?product=${productName}`


### PR DESCRIPTION
## Summary
- exit-intent 팝업 + scroll 구독 배너를 전체 페이지로 확장 (PR#59)
- .env.example 도메인 수정 (ai-native-playbook→ai-driven-architect revert)
- IndexNow keyLocation 파라미터 추가 (403 오류 해결)
- robots.txt sitemap URL 수정
- /ko 301 redirect 추가

## VP 승인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)