### PR TITLE
fix(sitemap): /ko hreflang 및 URL 제거 — GSC 에러 83개 수정

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -13,6 +13,8 @@ export default function robots(): MetadataRoute.Robots {
           "/_next/",
           "/thank-you",
           "/og-image",
+          "/ko",
+          "/ko/",
         ],
       },
       {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,11 +14,11 @@ function localizedUrl(locale: string, path: string): string {
   return path ? `${BASE_URL}/${locale}/${path}` : `${BASE_URL}/${locale}`;
 }
 
-// hreflang alternates — 영어는 prefix 없는 canonical + /en/ 둘 다 포함
+// hreflang alternates — /ko 는 301 리다이렉트로 차단되어 있으므로 제외
+// CEO 지시: richbukae 가격 충돌 방지를 위해 /ko 접근 차단 유지
 function buildAlternates(path: string): Record<string, string> {
   return {
     en: localizedUrl("en", path),
-    ko: localizedUrl("ko", path),
     ja: localizedUrl("ja", path),
     "x-default": canonicalUrl(path),
   };
@@ -75,8 +75,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     });
   }
 
-  // 2. /en/, /ko/, /ja/ 로캘 prefix URL
-  for (const locale of ["en", "ko", "ja"] as const) {
+  // 2. /en/, /ja/ 로캘 prefix URL (/ko 제외 — 301 리다이렉트 차단)
+  for (const locale of ["en", "ja"] as const) {
     for (const route of allRoutes) {
       result.push({
         url: localizedUrl(locale, route.path),


### PR DESCRIPTION
## Summary

- sitemap.ts `buildAlternates()`에서 `ko` 키 제거 (hreflang alternate에서 /ko URL 완전 제거)
- sitemap 섹션 2 로캘 루프를 `["en", "ko", "ja"]` → `["en", "ja"]`로 변경 (/ko/* URL 생성 차단)
- robots.ts에 `/ko`, `/ko/` disallow 추가 (크롤러 명시 차단)

## Background

- /ko 경로는 middleware에서 301 리다이렉트로 차단 중 (richbukae 가격 충돌 방지 — CEO 지시)
- sitemap에 redirect URL이 포함되면 GSC가 에러로 처리 → 색인 0개 원인
- /ko 라우트 page 코드 자체는 삭제 안 함 (redirect/차단만 유지)

## Test plan

- [ ] 빌드 성공 확인 (로컬 완료)
- [ ] /sitemap.xml에서 /ko/* URL 미포함 확인
- [ ] /robots.txt에서 Disallow: /ko 포함 확인
- [ ] GSC sitemap 재제출 후 에러 감소 모니터링

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>