### PR TITLE
perf: 2차 Performance 최적화 — ai-architect-global

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,8 @@ const nextConfig: NextConfig = {
       "next-intl",
       "react-markdown",
       "remark-gfm",
+      "gray-matter",
+      "reading-time",
       "@vercel/analytics",
       "@vercel/speed-insights",
     ],

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -202,8 +202,6 @@ export default async function LocaleLayout({
         <link rel="alternate" hrefLang="x-default" href={SITE_URL} />
         <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         {process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN && (
           <>
             <link rel="preconnect" href="https://cdn.paddle.com" crossOrigin="anonymous" />


### PR DESCRIPTION
## Summary

- `next/font/google`으로 이미 처리되는 Google Fonts preconnect 태그 2개 제거
  (`fonts.googleapis.com`, `fonts.gstatic.com` — next/font이 자체 최적화)
- `optimizePackageImports` 확장: `gray-matter`, `reading-time` 추가 (블로그 라이브러리)

## Expected Impact

- 불필요한 외부 preconnect 제거 → 네트워크 연결 오버헤드 감소
- Tree-shaking 개선으로 번들 크기 감소

## Test plan

- [ ] staging 배포 후 Lighthouse Performance 점수 확인
- [ ] 영어/일본어 로케일 정상 동작 확인
- [ ] 블로그 페이지 정상 동작 확인
- [ ] 결제 플로우 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)