### PR TITLE
feat: add mobile timed popup for exit-intent

### DIFF
--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -41,8 +41,8 @@ export default function ExitIntentPopup({ labels, variant = "A" }: { labels: Exi
     } catch {}
   }, []);
 
+  // Exit intent detection (desktop: mouseleave, mobile: 45s timer)
   useEffect(() => {
-    if (typeof window !== "undefined" && window.innerWidth < 768) return;
     try {
       if (localStorage.getItem(SUBSCRIBED_KEY)) return;
       const dismissed = localStorage.getItem(DISMISS_KEY);
@@ -52,6 +52,17 @@ export default function ExitIntentPopup({ labels, variant = "A" }: { labels: Exi
       }
     } catch {}
 
+    const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+
+    if (isMobile) {
+      // Mobile: show after 45 seconds of browsing
+      const timer = setTimeout(() => {
+        setVisible(true);
+      }, 45000);
+      return () => clearTimeout(timer);
+    }
+
+    // Desktop: exit intent detection
     function handleMouseLeave(e: MouseEvent) {
       if (e.clientY <= 0) {
         setVisible(true);


### PR DESCRIPTION
## Summary
- Add mobile timed popup (45s) to exit-intent subscription popup
- Previously exit-intent only worked on desktop (mouseleave event)
- Mobile users now see the subscription popup after 45 seconds of browsing

## Test plan
- [ ] Verify mobile viewport: popup appears after 45 seconds
- [ ] Verify desktop: exit-intent popup still triggers on mouseleave
- [ ] Verify dismiss persistence (14-day localStorage)
- [ ] Verify A/B CTA variants work correctly

Generated with Claude Code