### PR TITLE
feat: programmatic SEO pattern pages

### DIFF
--- a/src/app/[locale]/patterns/[slug]/page.tsx
+++ b/src/app/[locale]/patterns/[slug]/page.tsx
@@ -1,0 +1,219 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { setRequestLocale } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+import { patterns, getPatternBySlug } from "@/lib/patterns";
+import { books } from "@/lib/products";
+
+function escapeJsonLd(obj: object): string {
+  return JSON.stringify(obj)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
+
+export function generateStaticParams() {
+  return routing.locales.flatMap((locale) =>
+    patterns.map((p) => ({ locale, slug: p.slug }))
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const pattern = getPatternBySlug(slug);
+  if (!pattern) return {};
+
+  const title = `${pattern.title} | AI Native Playbook`;
+  const description = pattern.description;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `${BASE_URL}/patterns/${slug}`,
+      type: "article",
+      siteName: "AI Native Playbook",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+    alternates: {
+      canonical: `${BASE_URL}/patterns/${slug}`,
+    },
+  };
+}
+
+export default async function PatternPage({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
+  const { slug, locale } = await params;
+  setRequestLocale(locale);
+
+  const pattern = getPatternBySlug(slug);
+  if (!pattern) notFound();
+
+  const relatedBook = books.find((b) => b.slug === pattern.relatedBookSlug);
+  const otherPatterns = patterns.filter((p) => p.slug !== slug);
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: pattern.title,
+    description: pattern.description,
+    url: `${BASE_URL}/patterns/${slug}`,
+    author: {
+      "@type": "Organization",
+      name: "AI Native Playbook",
+      url: BASE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "AI Native Playbook",
+      url: BASE_URL,
+    },
+    about: {
+      "@type": "Thing",
+      name: `${pattern.sourceBook} by ${pattern.sourceAuthor}`,
+    },
+  };
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "AI Native Playbook",
+        item: BASE_URL,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Patterns",
+        item: `${BASE_URL}/patterns`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: pattern.title,
+        item: `${BASE_URL}/patterns/${slug}`,
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(articleJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(breadcrumbJsonLd) }}
+      />
+
+      <main className="mx-auto max-w-4xl px-4 py-12">
+        <nav className="mb-8 text-sm text-gray-500">
+          <Link href="/" className="hover:text-gray-700">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <Link href="/patterns" className="hover:text-gray-700">
+            Patterns
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">{pattern.title}</span>
+        </nav>
+
+        <h1 className="mb-2 text-3xl font-bold">{pattern.title}</h1>
+        <p className="mb-2 text-lg text-gray-500">{pattern.subtitle}</p>
+        <p className="mb-4 text-sm text-gray-400">
+          Based on <em>{pattern.sourceBook}</em> by {pattern.sourceAuthor}
+        </p>
+        <p className="mb-10 text-lg text-gray-600">{pattern.description}</p>
+
+        <section className="mb-12">
+          <h2 className="mb-4 text-xl font-semibold">Key Steps</h2>
+          <ol className="space-y-3">
+            {pattern.keySteps.map((step, i) => (
+              <li key={i} className="flex gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700">
+                  {i + 1}
+                </span>
+                <span className="text-gray-700">{step}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="mb-4 text-xl font-semibold">Use Cases</h2>
+          <ul className="space-y-2">
+            {pattern.useCases.map((uc, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-2 text-gray-600"
+              >
+                <span className="mt-1 text-green-500">&#10003;</span>
+                {uc}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {relatedBook && (
+          <section className="mb-12 rounded-xl border border-gray-200 p-6">
+            <h2 className="mb-2 text-lg font-semibold">Related Playbook</h2>
+            <Link
+              href={`/products/${relatedBook.slug}`}
+              className="group flex items-center gap-3 text-blue-600 hover:text-blue-800"
+            >
+              <span className="text-2xl">{relatedBook.icon}</span>
+              <div>
+                <p className="font-medium group-hover:underline">
+                  {relatedBook.title}
+                </p>
+                <p className="text-sm text-gray-500">{relatedBook.subtitle}</p>
+              </div>
+            </Link>
+          </section>
+        )}
+
+        <section>
+          <h2 className="mb-6 text-xl font-semibold">
+            Explore More Patterns
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {otherPatterns.map((p) => (
+              <Link
+                key={p.slug}
+                href={`/patterns/${p.slug}`}
+                className="rounded-lg border border-gray-200 p-4 transition hover:border-blue-200 hover:bg-blue-50"
+              >
+                <h3 className="font-medium">{p.title}</h3>
+                <p className="mt-1 text-sm text-gray-500 line-clamp-2">
+                  {p.description}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { setRequestLocale } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+import { patterns } from "@/lib/patterns";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export function generateMetadata(): Metadata {
+  return {
+    title: "AI Architecture Patterns | AI Native Playbook",
+    description:
+      "Proven business frameworks automated with AI. Value Ladder, Mass Movement, Dream 100, Story-Driven Copy, and Product Launch patterns.",
+    openGraph: {
+      title: "AI Architecture Patterns | AI Native Playbook",
+      description: "5 proven business frameworks automated with AI.",
+      url: `${BASE_URL}/patterns`,
+      type: "website",
+    },
+    alternates: {
+      canonical: `${BASE_URL}/patterns`,
+    },
+  };
+}
+
+function escapeJsonLd(obj: object): string {
+  return JSON.stringify(obj)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+export default async function PatternsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "AI Architecture Patterns",
+    description: "Proven business frameworks automated with AI",
+    url: `${BASE_URL}/patterns`,
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: patterns.map((p, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        item: {
+          "@type": "Article",
+          name: p.title,
+          description: p.description,
+          url: `${BASE_URL}/patterns/${p.slug}`,
+        },
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
+      />
+      <main className="mx-auto max-w-4xl px-4 py-12">
+        <h1 className="mb-4 text-3xl font-bold">AI Architecture Patterns</h1>
+        <p className="mb-10 text-lg text-gray-600">
+          Proven business frameworks from bestselling authors — automated with
+          AI. Each pattern gives you a step-by-step system you can implement
+          immediately.
+        </p>
+
+        <div className="space-y-6">
+          {patterns.map((p) => (
+            <Link
+              key={p.slug}
+              href={`/patterns/${p.slug}`}
+              className="group block rounded-xl border border-gray-200 p-6 transition hover:border-blue-300 hover:shadow-md"
+            >
+              <h2 className="mb-1 text-xl font-semibold group-hover:text-blue-600">
+                {p.title}
+              </h2>
+              <p className="mb-2 text-sm text-gray-500">{p.subtitle}</p>
+              <p className="mb-3 text-gray-600 line-clamp-2">
+                {p.description}
+              </p>
+              <p className="text-xs text-gray-400">
+                Based on <em>{p.sourceBook}</em> by {p.sourceAuthor}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { books } from "@/lib/products";
 import { getAllPosts } from "@/lib/blog";
+import { patterns } from "@/lib/patterns";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
 
@@ -41,6 +42,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "about", changeFrequency: "monthly", priority: 0.6, lastModified: new Date("2026-03-01") },
     { path: "faq", changeFrequency: "monthly", priority: 0.7, lastModified: new Date("2026-03-01") },
     { path: "blog", changeFrequency: "weekly", priority: 0.8, lastModified: new Date("2026-03-10") },
+    { path: "patterns", changeFrequency: "monthly", priority: 0.8, lastModified: new Date("2026-03-11") },
     { path: "terms", changeFrequency: "yearly", priority: 0.3, lastModified: new Date("2025-01-01") },
     { path: "privacy", changeFrequency: "yearly", priority: 0.3, lastModified: new Date("2025-01-01") },
     { path: "refund", changeFrequency: "yearly", priority: 0.3, lastModified: new Date("2025-01-01") },
@@ -60,7 +62,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: new Date(post.date),
   }));
 
-  const allRoutes = [...staticRoutes, ...productRoutes, ...blogRoutes];
+  const patternRoutes: RouteEntry[] = patterns.map((p) => ({
+    path: `patterns/${p.slug}`,
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+    lastModified: new Date("2026-03-11"),
+  }));
+
+  const allRoutes = [...staticRoutes, ...productRoutes, ...blogRoutes, ...patternRoutes];
   const result: MetadataRoute.Sitemap = [];
 
   // 1. prefix 없는 영어 canonical URL (hreflang alternates 포함)

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -1,0 +1,132 @@
+export interface Pattern {
+  slug: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  sourceBook: string;
+  sourceAuthor: string;
+  relatedBookSlug: string;
+  keySteps: string[];
+  useCases: string[];
+}
+
+export const patterns: Pattern[] = [
+  {
+    slug: "value-ladder-automation",
+    title: "Value Ladder AI Automation",
+    subtitle: "Build a 5-step customer ascension model with AI",
+    description:
+      "Automate Russell Brunson's Value Ladder framework using AI. Design your product ecosystem from lead magnets to high-ticket offers, with AI-generated content and positioning for each tier.",
+    sourceBook: "DotCom Secrets",
+    sourceAuthor: "Russell Brunson",
+    relatedBookSlug: "ai-marketing-architect",
+    keySteps: [
+      "Define your Dream Customer with AI-generated personas",
+      "Map the 5-step Value Ladder — AI identifies gaps and proposes new tiers",
+      "Generate Hook-Story-Offer content for each product level",
+      "Build the 7-Phase Funnel: Cold to Warm to Hot traffic sequences",
+      "Create Soap Opera Sequence: AI writes 5-day trust-building email series",
+    ],
+    useCases: [
+      "Online course creators launching their first product ladder",
+      "Coaches scaling from 1-on-1 to group programs",
+      "E-commerce businesses adding digital upsells",
+    ],
+  },
+  {
+    slug: "mass-movement-design",
+    title: "Mass Movement Design with AI",
+    subtitle: "Build a brand that leads a movement, not just sells a product",
+    description:
+      "Apply Russell Brunson's Expert Secrets framework using AI to design a Mass Movement. From defining your Charismatic Leader identity to crafting your Epiphany Bridge story and Perfect Webinar script.",
+    sourceBook: "Expert Secrets",
+    sourceAuthor: "Russell Brunson",
+    relatedBookSlug: "ai-brand-architect",
+    keySteps: [
+      "Define your Charismatic Leader identity, Cause, and New Opportunity",
+      "Craft the Epiphany Bridge: 8-step storytelling script with AI",
+      "Build Belief System Architecture: Big Domino + 3 false beliefs",
+      "Generate Perfect Webinar Script: complete 4-part AI-written script",
+      "Execute Dream 100 Traffic Strategy for audience building",
+    ],
+    useCases: [
+      "Personal brands building an engaged community",
+      "Thought leaders launching a new methodology",
+      "Consultants positioning as category creators",
+    ],
+  },
+  {
+    slug: "dream-100-traffic",
+    title: "Dream 100 AI Traffic Strategy",
+    subtitle:
+      "Find your customers where they already are — with AI",
+    description:
+      "Implement Russell Brunson's Traffic Secrets Dream 100 strategy using AI. Build complete customer avatars, identify 100 traffic sources, and generate platform-specific content strategies.",
+    sourceBook: "Traffic Secrets",
+    sourceAuthor: "Russell Brunson",
+    relatedBookSlug: "ai-traffic-architect",
+    keySteps: [
+      "AI-generated Dream Customer Avatar from demographic + behavioral data",
+      "Identify 100 places your dream customers congregate with AI research",
+      "Generate Hook-Story-Offer content optimized per platform",
+      "Design organic (Work Your Way In) and paid (Buy Your Way In) strategies",
+      "Build Follow-Up Funnel: AI email sequences for cold-to-buyer conversion",
+    ],
+    useCases: [
+      "SaaS startups seeking product-market fit traffic",
+      "Local businesses expanding to online audiences",
+      "Content creators diversifying traffic sources",
+    ],
+  },
+  {
+    slug: "story-driven-copy",
+    title: "Story-Driven AI Copywriting",
+    subtitle:
+      "Every word wins or loses sales — AI fixes the ones that lose",
+    description:
+      "Apply Jim Edwards' Copywriting Secrets with AI. Mine personal stories, structure Hero's Journey narratives, and generate high-conversion headlines and platform-specific copy.",
+    sourceBook: "Copywriting Secrets",
+    sourceAuthor: "Jim Edwards",
+    relatedBookSlug: "ai-story-architect",
+    keySteps: [
+      "Personal Story Mining: 5-step process for finding emotional turning points",
+      "Hero's Journey Formula: 7-step narrative arc designed by AI",
+      "10 Buying Motivators: AI identifies which core motivators drive your audience",
+      "Headline Arsenal: generate headlines across Curiosity, Benefit, Problem-Solution",
+      "Platform-Specific Copy: Hook, Story, Value, CTA for each channel",
+    ],
+    useCases: [
+      "Marketers optimizing landing page conversion rates",
+      "Email marketers improving open and click rates",
+      "Ad copywriters generating high-performing variations",
+    ],
+  },
+  {
+    slug: "product-launch-sequence",
+    title: "AI Product Launch Sequence",
+    subtitle: "Launch with a proven sequence — not guesswork",
+    description:
+      "Automate Jeff Walker's Product Launch Formula using AI. Design the 4-phase launch structure, embed 9 mental triggers naturally, and generate complete prelaunch content and launch email sequences.",
+    sourceBook: "Product Launch Formula",
+    sourceAuthor: "Jeff Walker",
+    relatedBookSlug: "ai-startup-architect",
+    keySteps: [
+      "PLF 4-Phase Structure: Pre-Prelaunch, PLC sequence, Launch, Post-Launch",
+      "Embed 9 Mental Triggers: Authority, Reciprocity, Scarcity, Social Proof",
+      "Sideways Sales Letter: AI generates 3-part Prelaunch Content sequence",
+      "7-Day Launch Email Sequence: every email from Cart Open to Final Close",
+      "Choose launch type: Seed (50-200), Internal (1K-5K), JV (10K+)",
+    ],
+    useCases: [
+      "Digital product creators planning their first launch",
+      "Course creators automating recurring launches",
+      "SaaS founders designing beta launch sequences",
+    ],
+  },
+];
+
+export const VALID_PATTERN_SLUGS = patterns.map((p) => p.slug);
+
+export function getPatternBySlug(slug: string): Pattern | undefined {
+  return patterns.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
## Summary
- Add `/patterns/[slug]` pages for 5 AI architecture patterns (value-ladder, mass-movement, dream-100, story-driven-copy, product-launch)
- Add `/patterns` index page with CollectionPage JSON-LD
- Each pattern page has Article JSON-LD, BreadcrumbList, related book link, cross-pattern internal linking
- Update sitemap.ts with pattern routes for en/ja locales

## New indexable pages: 6 (1 index + 5 patterns) x 2 locales = 12 URLs in sitemap

## Test plan
- [ ] Build succeeds (`npx next build`)
- [ ] `/en/patterns` index renders with all 5 patterns
- [ ] `/en/patterns/value-ladder-automation` renders correctly
- [ ] JSON-LD validates on pattern detail pages
- [ ] Sitemap includes `/patterns/*` URLs

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>