### PR TITLE
fix: structured data JSON-LD validation

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -83,24 +83,6 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
     },
     {
       "@context": "https://schema.org",
-      "@type": "Organization",
-      "@id": `${siteUrl}/#organization`,
-      name: "NEWBIZSOFT",
-      url: siteUrl,
-      description: "AI-powered business tools for entrepreneurs and small teams.",
-      brand: {
-        "@type": "Brand",
-        name: "AI Native Playbook Series",
-      },
-      contactPoint: {
-        "@type": "ContactPoint",
-        email: "contact@newbizsoft.com",
-        contactType: "customer service",
-      },
-      sameAs: [],
-    },
-    {
-      "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       itemListElement: [
         { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -147,7 +147,6 @@ function buildSiteJsonLd(locale: string, siteUrl: string) {
           caption: "AI Native Playbook Series",
         },
         image: { "@id": `${siteUrl}/#logo` },
-        sameAs: [],
         contactPoint: {
           "@type": "ContactPoint",
           email: "contact@newbizsoft.com",


### PR DESCRIPTION
## Summary
- Remove empty `sameAs: []` from Organization schema in layout (invalid per Google Rich Results spec)
- Remove duplicate Organization `@id` declaration from about page (already defined in layout, avoids conflicting schemas)

## Test plan
- [ ] Verify JSON-LD renders correctly on homepage and about page
- [ ] Run Google Rich Results Test on key pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)