### PR TITLE
fix(ai-architect): clean up 404/500 error pages

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import NotFoundSubscribeForm from "@/components/NotFoundSubscribeForm";
 
 export const metadata: Metadata = {
   title: "Page Not Found | AI Native Playbook Series",
@@ -37,10 +36,6 @@ export default function NotFound() {
             <span className="text-text-secondary/60">KR</span>{" "}
             요청하신 페이지를 찾을 수 없습니다.
           </p>
-          <p className="text-sm opacity-75">
-            <span className="text-text-secondary/60">JP</span>{" "}
-            お探しのページは見つかりませんでした。
-          </p>
         </div>
 
         {/* Primary CTA */}
@@ -51,16 +46,10 @@ export default function NotFound() {
           >
             Back to Home
           </Link>
-          <Link
-            href="/ja"
-            className="border border-gold/30 text-text-secondary px-6 py-3 rounded-xl hover:border-gold/60 hover:text-text-primary transition-all"
-          >
-            日本語 ホーム
-          </Link>
         </div>
 
         {/* Internal navigation links */}
-        <div className="flex flex-wrap gap-2 justify-center mb-10">
+        <div className="flex flex-wrap gap-2 justify-center">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -70,15 +59,6 @@ export default function NotFound() {
               {link.label}
             </Link>
           ))}
-        </div>
-
-        {/* Subscribe CTA */}
-        <div className="border border-gold/20 rounded-2xl p-6 bg-navy-dark/50">
-          <p className="text-sm font-semibold text-gold mb-1">Free AI Business Checklist</p>
-          <p className="text-xs text-text-secondary mb-4">
-            Get weekly AI business insights delivered to your inbox.
-          </p>
-          <NotFoundSubscribeForm />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Remove subscribe CTA block (`NotFoundSubscribeForm`) from `not-found.tsx` — CEO rule: 1페이지 1목적, subscribe only on `/subscribe` page
- Remove `/ja` Japanese home link from `not-found.tsx` — no new JP content promotion
- Remove Japanese message (`お探しのページは見つかりませんでした`) — keep English + Korean only
- Remove unused `NotFoundSubscribeForm` import
- `error.tsx` and `global-error.tsx` reviewed and confirmed clean (no subscribe CTAs, proper home links, branded styling)

## Test plan

- [x] `npm run build` passes (95/95 static pages generated)
- [x] `not-found.tsx` renders with English + Korean messages only
- [x] No subscribe form on 404 page
- [x] No `/ja` link on 404 page
- [x] `error.tsx` and `global-error.tsx` unchanged and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed Japanese language option from the 404 error page while retaining other language support
  * Removed newsletter subscription prompt from the 404 error page
  * Improved layout spacing and navigation flow on the 404 error page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->