### PR TITLE
fix(seo): fill missing twitter card metadata on blog, free-guide, about

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -55,6 +55,12 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       url: canonicalUrl,
       images: [{ url: `${siteUrl}/opengraph-image`, width: 1200, height: 630, alt: meta.title }],
     },
+    twitter: {
+      card: "summary_large_image",
+      title: meta.title,
+      description: meta.description,
+      images: [`${siteUrl}/opengraph-image`],
+    },
   };
 }
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -67,6 +67,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       card: "summary_large_image",
       title: meta.title,
       description: meta.ogDescription,
+      images: [`${SITE_URL}/opengraph-image`],
     },
   };
 }

--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -40,6 +40,13 @@ export async function generateMetadata({
         },
       ],
     },
+    twitter: {
+      card: "summary_large_image",
+      title: "Free AI Business Automation Starter Guide",
+      description:
+        "Get a free guide that shows you how to use AI to automate 6 proven business frameworks. Instant PDF download.",
+      images: [`${SITE_URL}/opengraph-image`],
+    },
     robots: {
       index: true,
       follow: true,


### PR DESCRIPTION
## Summary
- **blog/page.tsx**: `twitter.images` was missing despite card/title/description being present
- **free-guide/page.tsx**: entire `twitter` block was absent — added card, title, description, images
- **about/page.tsx**: entire `twitter` block was absent — added card, title, description, images

All other pages (home, pricing, products, bundle, faq) already had complete OG + Twitter metadata and were left unchanged.

## Pages audited
| Page | Before | After |
|---|---|---|
| home | PASS | PASS |
| blog | twitter.images missing | PASS |
| free-guide | twitter block missing | PASS |
| pricing | PASS | PASS |
| products | PASS | PASS |
| bundle | PASS | PASS |
| about | twitter block missing | PASS |
| faq | PASS | PASS |

## Test plan
- [x] `npm run build` passes (95/95 pages generated)
- [x] No new opengraph-image.tsx files created (root fallback used)
- [x] No existing OG images or descriptions changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Twitter/X sharing across multiple pages by adding comprehensive social card metadata, including title, description, and image previews to enhance how content appears when shared on social media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->