### PR TITLE
[ai-architect-global] feat(seo): add JSON-LD schemas to free-guide and pricing pages

### DIFF
--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -77,6 +77,10 @@ const benefits = [
   },
 ];
 
+function escapeJsonLd(json: string): string {
+  return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
 export default async function FreeGuidePage({
   params,
 }: {
@@ -85,7 +89,47 @@ export default async function FreeGuidePage({
   const { locale } = await params;
   setRequestLocale(locale);
 
+  const canonicalUrl =
+    locale === "en"
+      ? `${SITE_URL}/free-guide`
+      : `${SITE_URL}/${locale}/free-guide`;
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Free AI Business Automation Starter Guide",
+    description:
+      "Download your free AI starter guide. Learn how to automate marketing funnels, sales copy, and product launches using AI. No purchase required.",
+    url: canonicalUrl,
+    inLanguage: locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US",
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  };
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: SITE_URL },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Free Guide",
+        item: `${SITE_URL}/free-guide`,
+      },
+    ],
+  };
+
   return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(webPageJsonLd)) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(breadcrumbJsonLd)) }}
+      />
     <div className="min-h-screen pt-24 pb-20">
       {/* Hook */}
       <section className="text-center max-w-3xl mx-auto px-4 mb-16">
@@ -249,5 +293,6 @@ export default async function FreeGuidePage({
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -146,12 +146,57 @@ export default async function PricingPage({
     ],
   };
 
+  const canonicalPricingUrl =
+    locale === "en" ? `${SITE_URL}/pricing` : `${SITE_URL}/${locale}/pricing`;
+
+  const offerCatalogJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "OfferCatalog",
+    name: "AI Native Playbook Series — Pricing",
+    description:
+      "Get all 6 AI business automation guides for $47 (save $55) or start with a single volume for $17.",
+    url: canonicalPricingUrl,
+    numberOfItems: 2,
+    itemListElement: [
+      {
+        "@type": "Offer",
+        name: "Individual Volume",
+        description:
+          "1 premium PDF guide with AI system prompts, real case studies, and a 5-day quickstart checklist.",
+        price: "17",
+        priceCurrency: "USD",
+        availability: "https://schema.org/InStock",
+        priceValidUntil: "2026-12-31",
+        url: `${SITE_URL}/products`,
+        seller: { "@id": `${SITE_URL}/#organization` },
+      },
+      {
+        "@type": "Offer",
+        name: "Complete Bundle — All 6 Volumes",
+        description:
+          "All 6 AI business automation guides plus 3 exclusive bonuses: Master Template, Execution Tracker, and Quick Reference Card.",
+        price: String(bundle.price),
+        priceCurrency: "USD",
+        availability: "https://schema.org/InStock",
+        priceValidUntil: "2026-12-31",
+        url: `${SITE_URL}/bundle`,
+        seller: { "@id": `${SITE_URL}/#organization` },
+      },
+    ],
+  };
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: escapeJsonLd(JSON.stringify(breadcrumbJsonLd)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: escapeJsonLd(JSON.stringify(offerCatalogJsonLd)),
         }}
       />
 


### PR DESCRIPTION
## Summary

- **free-guide page**: Added `WebPage` + `BreadcrumbList` JSON-LD (previously had zero structured data)
- **pricing page**: Added `OfferCatalog` schema with two `Offer` entries — individual volume ($17) and complete bundle ($47) — alongside the existing `BreadcrumbList`

## Audit findings (all 8 pages checked)

| Page | Before | After |
|------|--------|-------|
| `layout.tsx` (root) | Organization + WebSite — COMPLETE | No change |
| `page.tsx` (home) | FAQPage + ItemList — COMPLETE | No change |
| `blog/page.tsx` | CollectionPage/Blog + BreadcrumbList — COMPLETE | No change |
| `blog/[slug]/page.tsx` | BlogPosting + BreadcrumbList — COMPLETE | No change |
| `free-guide/page.tsx` | None | Added WebPage + BreadcrumbList |
| `pricing/page.tsx` | BreadcrumbList only | Added OfferCatalog (2 Offers) |
| `products/page.tsx` | BreadcrumbList + CollectionPage + ItemList — COMPLETE | No change |
| `faq/page.tsx` | FAQPage + BreadcrumbList — COMPLETE | No change |
| `about/page.tsx` | AboutPage + BreadcrumbList — COMPLETE | No change |

## Test plan

- [ ] `npm run build` passes (verified — zero errors)
- [ ] Validate `/free-guide` JSON-LD with Google Rich Results Test
- [ ] Validate `/pricing` JSON-LD with Google Rich Results Test
- [ ] Confirm no regressions on existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)