### PR TITLE
seo: optimize robots.txt — AI crawler blocking + crawl delay

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -10,13 +10,48 @@ export default function robots(): MetadataRoute.Robots {
         allow: "/",
         disallow: [
           "/api/",
-          "/_next/",
+          "/_next/static/",
           "/admin/",
           "/thank-you",
-          "/opengraph-image",
+          "/opengraph-image*",
+          "/icon*",
+          "/apple-icon*",
           "/ko",
           "/ko/",
         ],
+        crawlDelay: 10,
+      },
+      {
+        userAgent: "GPTBot",
+        disallow: "/",
+      },
+      {
+        userAgent: "ChatGPT-User",
+        disallow: "/",
+      },
+      {
+        userAgent: "Google-Extended",
+        disallow: "/",
+      },
+      {
+        userAgent: "CCBot",
+        disallow: "/",
+      },
+      {
+        userAgent: "anthropic-ai",
+        disallow: "/",
+      },
+      {
+        userAgent: "ClaudeBot",
+        disallow: "/",
+      },
+      {
+        userAgent: "cohere-ai",
+        disallow: "/",
+      },
+      {
+        userAgent: "Bytespider",
+        disallow: "/",
       },
     ],
     sitemap: [


### PR DESCRIPTION
## Summary

- Replace `/_next/` with `/_next/static/` for more precise static asset blocking
- Add wildcard disallow for `/opengraph-image*`, `/icon*`, `/apple-icon*`
- Add `crawlDelay: 10` for all general bots
- Block 8 AI crawlers: GPTBot, ChatGPT-User, Google-Extended, CCBot, anthropic-ai, ClaudeBot, cohere-ai, Bytespider
- Preserve existing rules: `/ko`, `/ko/`, `/thank-you`, `/api/`, `/admin/`

## Test plan

- [x] `npm run build` passed — no TypeScript errors
- [x] `/robots.txt` route confirmed in build output
- [ ] Verify robots.txt output at https://ai-driven-architect.com/robots.txt after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated crawling configuration to refine asset indexing patterns and apply crawler-specific access rules, including adjusted crawl delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->