### PR TITLE
fix(cta): [ai-architect] 홈페이지 구독 팝업 제외 (1페이지 1목적)

### DIFF
--- a/src/components/IntlClientShell.tsx
+++ b/src/components/IntlClientShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import dynamic from "next/dynamic";
 import { getCtaVariant, CTA_VARIANTS, type CtaVariant } from "@/lib/cta-config";
 
@@ -37,7 +38,18 @@ type ScrollBannerLabels = {
  * Renders only the deferred interactive overlays (exit intent popup + scroll banner).
  * <main> content is intentionally kept outside this client boundary in layout.tsx
  * so server-rendered page content is not included in the client JS bundle.
+ *
+ * 1페이지 1목적 원칙: homepage paths (/, /en, /ja) suppress all subscribe overlays.
  */
+
+/** Locale-only paths where the homepage (sales page) lives — popups suppressed here. */
+const HOMEPAGE_PATHS = new Set(["/", "/en", "/ja"]);
+
+function isHomepage(pathname: string): boolean {
+  // Match exact locale roots: /, /en, /ja — with or without trailing slash
+  return HOMEPAGE_PATHS.has(pathname) || HOMEPAGE_PATHS.has(pathname.replace(/\/$/, ""));
+}
+
 export default function IntlClientShell({
   exitPopupLabels,
   scrollBannerLabels,
@@ -45,6 +57,7 @@ export default function IntlClientShell({
   exitPopupLabels: ExitPopupLabels;
   scrollBannerLabels: ScrollBannerLabels;
 }) {
+  const pathname = usePathname();
   const [variant, setVariant] = useState<CtaVariant>("A");
 
   useEffect(() => {
@@ -61,6 +74,11 @@ export default function IntlClientShell({
     variant === "B"
       ? { ...exitPopupLabels, ...CTA_VARIANTS.exitIntent.B }
       : exitPopupLabels;
+
+  // 1페이지 1목적 원칙: 홈페이지(판매 전용)에서는 구독 팝업/배너 표시 안 함
+  if (isHomepage(pathname)) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- `IntlClientShell.tsx`에 `usePathname()` 추가
- `HOMEPAGE_PATHS` Set(`/`, `/en`, `/ja`)으로 홈페이지 경로 판별
- 홈페이지에서 `ExitIntentPopup` + `ScrollSubscribeBanner` 렌더링 null 반환
- 블로그(`/blog/*`), `/free-guide/*`, 기타 콘텐츠 페이지는 팝업 계속 활성화

## 변경 파일
- `src/components/IntlClientShell.tsx`

## 배경
CEO 1페이지 1목적 원칙: 홈페이지 = 판매 전용. 구독 팝업/배너는 콘텐츠 페이지에서만 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscribe overlays are now suppressed on homepage paths, improving the user experience for homepage visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->