### PR TITLE
feat(seo): [ai-architect] JSON-LD structured data 강화

### DIFF
--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -94,16 +94,26 @@ export default async function FreeGuidePage({
       ? `${SITE_URL}/free-guide`
       : `${SITE_URL}/${locale}/free-guide`;
 
-  const webPageJsonLd = {
+  const courseJsonLd = {
     "@context": "https://schema.org",
-    "@type": "WebPage",
+    "@type": "Course",
     name: "Free AI Business Automation Starter Guide",
     description:
       "Download your free AI starter guide. Learn how to automate marketing funnels, sales copy, and product launches using AI. No purchase required.",
     url: canonicalUrl,
     inLanguage: locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US",
-    isPartOf: { "@id": `${SITE_URL}/#website` },
-    publisher: { "@id": `${SITE_URL}/#organization` },
+    isAccessibleForFree: true,
+    educationalLevel: "Beginner",
+    provider: {
+      "@type": "Organization",
+      name: "AI Native Playbook",
+      url: SITE_URL,
+    },
+    hasCourseInstance: {
+      "@type": "CourseInstance",
+      courseMode: "online",
+      courseWorkload: "PT30M",
+    },
   };
 
   const breadcrumbJsonLd = {
@@ -124,7 +134,7 @@ export default async function FreeGuidePage({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(webPageJsonLd)) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(courseJsonLd)) }}
       />
       <script
         type="application/ld+json"

--- a/src/app/[locale]/patterns/[slug]/page.tsx
+++ b/src/app/[locale]/patterns/[slug]/page.tsx
@@ -70,12 +70,18 @@ export default async function PatternPage({
   const relatedBook = books.find((b) => b.slug === pattern.relatedBookSlug);
   const otherPatterns = patterns.filter((p) => p.slug !== slug);
 
-  const articleJsonLd = {
+  const howToJsonLd = {
     "@context": "https://schema.org",
-    "@type": "Article",
-    headline: pattern.title,
+    "@type": "HowTo",
+    name: pattern.title,
     description: pattern.description,
     url: `${BASE_URL}/patterns/${slug}`,
+    step: pattern.keySteps.map((step, i) => ({
+      "@type": "HowToStep",
+      position: i + 1,
+      name: step,
+      text: step,
+    })),
     author: {
       "@type": "Organization",
       name: "AI Native Playbook",
@@ -85,10 +91,6 @@ export default async function PatternPage({
       "@type": "Organization",
       name: "AI Native Playbook",
       url: BASE_URL,
-    },
-    about: {
-      "@type": "Thing",
-      name: `${pattern.sourceBook} by ${pattern.sourceAuthor}`,
     },
   };
 
@@ -121,7 +123,7 @@ export default async function PatternPage({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(articleJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(howToJsonLd) }}
       />
       <script
         type="application/ld+json"

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -44,7 +44,7 @@ export default async function PatternsPage({
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const jsonLd = {
+  const collectionPageJsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     name: "AI Architecture Patterns",
@@ -55,21 +55,31 @@ export default async function PatternsPage({
       itemListElement: patterns.map((p, i) => ({
         "@type": "ListItem",
         position: i + 1,
-        item: {
-          "@type": "Article",
-          name: p.title,
-          description: p.description,
-          url: `${BASE_URL}/patterns/${p.slug}`,
-        },
+        name: p.title,
+        url: `${BASE_URL}/patterns/${p.slug}`,
+        description: p.description,
       })),
     },
+  };
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "AI Native Playbook", item: BASE_URL },
+      { "@type": "ListItem", position: 2, name: "Patterns", item: `${BASE_URL}/patterns` },
+    ],
   };
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(collectionPageJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(breadcrumbJsonLd) }}
       />
       <main className="mx-auto max-w-4xl px-4 py-12">
         <h1 className="mb-4 text-3xl font-bold">AI Architecture Patterns</h1>


### PR DESCRIPTION
## Summary

- `patterns/page.tsx`: CollectionPage의 ItemList을 중첩 Article 구조에서 직접 ListItem(name/url/description) 구조로 개선, BreadcrumbList 추가
- `patterns/[slug]/page.tsx`: Article 스키마를 HowTo 스키마로 업그레이드 — `keySteps` 배열을 `HowToStep[]`으로 매핑하여 Google 리치 결과 적격 구조 확보
- `free-guide/page.tsx`: WebPage 스키마를 Course 스키마로 업그레이드 — `isAccessibleForFree: true`, `educationalLevel: "Beginner"`, `provider` Organization, `hasCourseInstance` 포함
- `bundle/page.tsx`: 기존 Product + AggregateOffer + BreadcrumbList 이미 완비 — 변경 없음

## Test plan

- [ ] Google Rich Results Test로 각 페이지 JSON-LD 유효성 확인
  - https://ai-driven-architect.com/patterns → CollectionPage + BreadcrumbList
  - https://ai-driven-architect.com/patterns/value-ladder-automation → HowTo + BreadcrumbList
  - https://ai-driven-architect.com/free-guide → Course + BreadcrumbList
  - https://ai-driven-architect.com/bundle → Product + AggregateOffer + BreadcrumbList (기존 유지)
- [ ] `npm run build` 빌드 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced structured data for free guide content, now marked as an educational course with accessibility information
  * Updated patterns content schema for better search engine understanding of instructional steps
  * Added breadcrumb navigation support to the patterns directory for improved site navigation visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->