### PR TITLE
feat(seo): [ai-architect] 내부 링킹 강화

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -246,6 +246,20 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         </div>
       )}
 
+      {/* Free Guide CTA */}
+      <div className="mt-6 flex items-center justify-between gap-4 p-4 bg-navy-dark/60 border border-white/10 rounded-xl hover:border-gold/20 transition-colors">
+        <div>
+          <p className="text-sm font-semibold text-text-primary">Free AI Business Guide</p>
+          <p className="text-xs text-text-secondary mt-0.5">Download the free starter guide — no purchase required.</p>
+        </div>
+        <Link
+          href="/free-guide"
+          className="shrink-0 inline-flex items-center gap-1.5 text-sm font-semibold text-gold hover:text-gold-light transition-colors"
+        >
+          Get Free Guide <span aria-hidden="true">→</span>
+        </Link>
+      </div>
+
       <div className="mt-8 pt-8 border-t border-white/10 text-center">
         <p className="text-text-secondary mb-2">Get weekly AI business frameworks — every Friday.</p>
         <p className="text-xs text-text-muted">500+ entrepreneurs subscribed · No spam · Unsubscribe anytime</p>

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -203,6 +203,7 @@ export default async function BlogPage({
           <div className="flex flex-wrap gap-3 justify-center">
             <Link href="/products" className="text-sm text-gold hover:text-gold-light transition-colors">Products</Link>
             <Link href="/bundle" className="text-sm text-gold hover:text-gold-light transition-colors">Bundle</Link>
+            <Link href="/free-guide" className="text-sm text-gold hover:text-gold-light transition-colors">Free Guide</Link>
             <Link href="/about" className="text-sm text-gold hover:text-gold-light transition-colors">About</Link>
             <Link href="/faq" className="text-sm text-gold hover:text-gold-light transition-colors">FAQ</Link>
           </div>

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -287,6 +287,16 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
           })}
         </div>
       </div>
+
+      {/* Related pages */}
+      <nav className="max-w-5xl mx-auto px-4 mt-14 pt-8 border-t border-white/10" aria-label="Related pages">
+        <div className="flex flex-wrap gap-3 justify-center">
+          <Link href="/blog" className="text-sm text-gold hover:text-gold-light transition-colors">Blog</Link>
+          <Link href="/free-guide" className="text-sm text-gold hover:text-gold-light transition-colors">Free Guide</Link>
+          <Link href="/bundle" className="text-sm text-gold hover:text-gold-light transition-colors">Bundle</Link>
+          <Link href="/faq" className="text-sm text-gold hover:text-gold-light transition-colors">FAQ</Link>
+        </div>
+      </nav>
     </div>
     </>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,6 +38,7 @@ export default async function Footer() {
               <li><Link href="/products" className="hover:text-gold transition-colors">{t("individualBooks")}</Link></li>
               <li><Link href="/pricing" className="hover:text-gold transition-colors">{tn("pricing")}</Link></li>
               <li><Link href="/blog" className="hover:text-gold transition-colors">{tn("blog")}</Link></li>
+              <li><Link href="/free-guide" className="hover:text-gold transition-colors">{t("freeGuide")}</Link></li>
               <li><Link href="/about" className="hover:text-gold transition-colors">{tn("about")}</Link></li>
               <li><Link href="/faq" className="hover:text-gold transition-colors">{tn("faq")}</Link></li>
             </ul>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -48,7 +48,8 @@
     "completeBundle": "Complete Bundle — $47",
     "individualBooks": "Individual Books — $17 each",
     "rights": "All rights reserved",
-    "instantPdf": "Instant PDF download"
+    "instantPdf": "Instant PDF download",
+    "freeGuide": "Free Guide"
   },
   "blog": {
     "title": "AI Business Blog",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -48,7 +48,8 @@
     "completeBundle": "完全バンドル — $47",
     "individualBooks": "個別書籍 — 各$17",
     "rights": "All rights reserved",
-    "instantPdf": "即時PDFダウンロード"
+    "instantPdf": "即時PDFダウンロード",
+    "freeGuide": "無料ガイド"
   },
   "blog": {
     "title": "AIビジネスブログ",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -48,7 +48,8 @@
     "completeBundle": "전체 번들 — $47",
     "individualBooks": "개별 도서 — 각 $17",
     "rights": "All rights reserved",
-    "instantPdf": "즉시 PDF 다운로드"
+    "instantPdf": "즉시 PDF 다운로드",
+    "freeGuide": "무료 가이드"
   },
   "blog": {
     "title": "AI 비즈니스 블로그",


### PR DESCRIPTION
## Summary

- Footer info 섹션에 `/free-guide` 링크 추가 (en/ko/ja 3개 언어 번역 포함)
- 블로그 포스트(`/blog/[slug]`) 하단 Related Products 아래 Free Guide CTA 배너 추가
- 블로그 인덱스(`/blog`) Related Pages nav에 `/free-guide` 항목 추가
- 제품 페이지(`/products`) 하단에 Related Pages nav 신설 — Blog · Free Guide · Bundle · FAQ

## Context

`/free-guide` 페이지가 내부 링크 없이 고립된 상태였음. 크롤링 깊이 개선 + 페이지 권위 분산을 위해 블로그/제품/푸터에서 연결.

## Rules Followed

- 홈페이지 미수정 (1페이지 1목적 원칙 준수)
- 서비스 간 크로스 프로모션 없음
- 기존 Tailwind 스타일 패턴 유지
- Next.js Link 컴포넌트 + locale prefix 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Free AI Business Guide call-to-action blocks in blog posts and product pages.
  * Introduced Free Guide navigation links in blog, products, and footer sections.
  * Expanded multi-language support with Free Guide translations in English, Japanese, and Korean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->