### PR TITLE
[ai-architect] feat: Open Graph image optimization

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -45,7 +45,7 @@ export default async function Image({ params }: { params: { slug: string; locale
             textTransform: "uppercase",
           }}
         >
-          AI ARCHITECT SERIES — BLOG
+          AI NATIVE PLAYBOOK — BLOG
         </div>
         <div
           style={{
@@ -79,7 +79,7 @@ export default async function Image({ params }: { params: { slug: string; locale
             fontWeight: "600",
           }}
         >
-          ai-driven-architect.com
+          AI Native Playbook Series
         </div>
       </div>
     ),

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -46,7 +46,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       siteName: "AI Native Playbook Series",
       images: [
         {
-          url: `${siteUrl}/opengraph-image`,
+          url: locale === "en"
+            ? `${siteUrl}/blog/${slug}/opengraph-image`
+            : `${siteUrl}/${locale}/blog/${slug}/opengraph-image`,
           width: 1200,
           height: 630,
           alt: `${post.title} | AI Native Playbook Series`,
@@ -57,7 +59,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       card: "summary_large_image",
       title: post.title,
       description: post.description,
-      images: [`${siteUrl}/opengraph-image`],
+      images: [
+        locale === "en"
+          ? `${siteUrl}/blog/${slug}/opengraph-image`
+          : `${siteUrl}/${locale}/blog/${slug}/opengraph-image`,
+      ],
     },
     alternates: {
       canonical: canonicalUrl,
@@ -118,7 +124,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     dateModified: post.date,
     image: {
       "@type": "ImageObject",
-      url: `${siteUrl}/opengraph-image`,
+      url: locale === "en"
+        ? `${siteUrl}/blog/${slug}/opengraph-image`
+        : `${siteUrl}/${locale}/blog/${slug}/opengraph-image`,
       width: 1200,
       height: 630,
     },

--- a/src/app/[locale]/blog/opengraph-image.tsx
+++ b/src/app/[locale]/blog/opengraph-image.tsx
@@ -1,0 +1,156 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "AI Business Blog — Latest Insights & Frameworks | AI Native Playbook";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: { locale: string } }) {
+  const locale = params.locale || "en";
+
+  const LOCALE_TITLE: Record<string, string> = {
+    en: "AI Business Blog",
+    ko: "AI 비즈니스 블로그",
+    ja: "AIビジネスブログ",
+  };
+
+  const LOCALE_SUBTITLE: Record<string, string> = {
+    en: "Latest Insights & Frameworks for AI-Powered Entrepreneurs",
+    ko: "AI 기반 기업가를 위한 최신 인사이트 및 프레임워크",
+    ja: "AIを活用する起業家のための最新インサイト",
+  };
+
+  const title = LOCALE_TITLE[locale] || LOCALE_TITLE.en;
+  const subtitle = LOCALE_SUBTITLE[locale] || LOCALE_SUBTITLE.en;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #060a14 0%, #0d1529 50%, #060a14 100%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px 80px",
+          position: "relative",
+        }}
+      >
+        {/* Gold top bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "4px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+
+        {/* Left accent bar */}
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: "6px",
+            background: "linear-gradient(180deg, #3b82f6, #1d4ed8, #3b82f6)",
+          }}
+        />
+
+        {/* Blog label */}
+        <div
+          style={{
+            background: "rgba(59,130,246,0.15)",
+            border: "1px solid rgba(59,130,246,0.35)",
+            color: "#60a5fa",
+            fontSize: "13px",
+            fontWeight: "700",
+            padding: "6px 20px",
+            borderRadius: "100px",
+            marginBottom: "28px",
+            letterSpacing: "2px",
+            textTransform: "uppercase",
+          }}
+        >
+          AI NATIVE PLAYBOOK — BLOG
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: "58px",
+            fontWeight: "800",
+            color: "#f1f5f9",
+            lineHeight: 1.1,
+            marginBottom: "20px",
+            maxWidth: "900px",
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: "24px",
+            fontWeight: "400",
+            color: "#94a3b8",
+            lineHeight: 1.4,
+            maxWidth: "780px",
+            marginBottom: "40px",
+          }}
+        >
+          {subtitle}
+        </div>
+
+        {/* Topic pills */}
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+            flexWrap: "wrap",
+          }}
+        >
+          {["AI Marketing", "Sales Funnels", "Copywriting", "Business Growth"].map((tag) => (
+            <div
+              key={tag}
+              style={{
+                background: "rgba(255,255,255,0.05)",
+                border: "1px solid rgba(255,255,255,0.1)",
+                color: "#cbd5e1",
+                fontSize: "14px",
+                fontWeight: "600",
+                padding: "8px 18px",
+                borderRadius: "8px",
+              }}
+            >
+              {tag}
+            </div>
+          ))}
+        </div>
+
+        {/* Branding */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "15px",
+            color: "#e2b714",
+            fontWeight: "600",
+            opacity: 0.8,
+          }}
+        >
+          AI Native Playbook Series
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -61,13 +61,26 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       url: canonicalUrl,
       siteName: "AI Native Playbook Series",
       locale: locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US",
-      images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: meta.title }],
+      images: [
+        {
+          url: locale === "en"
+            ? `${SITE_URL}/blog/opengraph-image`
+            : `${SITE_URL}/${locale}/blog/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: meta.title,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
       title: meta.title,
       description: meta.ogDescription,
-      images: [`${SITE_URL}/opengraph-image`],
+      images: [
+        locale === "en"
+          ? `${SITE_URL}/blog/opengraph-image`
+          : `${SITE_URL}/${locale}/blog/opengraph-image`,
+      ],
     },
   };
 }

--- a/src/app/[locale]/free-guide/opengraph-image.tsx
+++ b/src/app/[locale]/free-guide/opengraph-image.tsx
@@ -1,0 +1,153 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Free AI Business Guide - AI Native Playbook";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: { locale: string } }) {
+  const locale = params.locale || "en";
+
+  const LOCALE_TITLE: Record<string, string> = {
+    en: "Free AI Business Starter Guide",
+    ko: "무료 AI 비즈니스 스타터 가이드",
+    ja: "無料AIビジネスガイド",
+  };
+
+  const LOCALE_SUBTITLE: Record<string, string> = {
+    en: "Learn how AI automates 6 proven business frameworks — instant download",
+    ko: "6가지 검증된 비즈니스 프레임워크를 AI로 자동화하는 방법",
+    ja: "6つの実証済みフレームワークをAIで自動化する方法",
+  };
+
+  const title = LOCALE_TITLE[locale] || LOCALE_TITLE.en;
+  const subtitle = LOCALE_SUBTITLE[locale] || LOCALE_SUBTITLE.en;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #1a0f00 0%, #2d1a00 40%, #1a0f00 100%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px 80px",
+          position: "relative",
+        }}
+      >
+        {/* Gold top bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "6px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+
+        {/* FREE badge */}
+        <div
+          style={{
+            background: "rgba(226,183,20,0.15)",
+            border: "2px solid rgba(226,183,20,0.5)",
+            color: "#e2b714",
+            fontSize: "14px",
+            fontWeight: "800",
+            padding: "8px 28px",
+            borderRadius: "100px",
+            marginBottom: "32px",
+            letterSpacing: "3px",
+            textTransform: "uppercase",
+          }}
+        >
+          FREE GUIDE
+        </div>
+
+        {/* Download icon circle */}
+        <div
+          style={{
+            width: "72px",
+            height: "72px",
+            background: "rgba(226,183,20,0.12)",
+            border: "2px solid rgba(226,183,20,0.3)",
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            marginBottom: "28px",
+            fontSize: "32px",
+          }}
+        >
+          📥
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: "52px",
+            fontWeight: "800",
+            color: "#f1f5f9",
+            textAlign: "center",
+            lineHeight: 1.15,
+            marginBottom: "20px",
+            maxWidth: "900px",
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: "22px",
+            fontWeight: "400",
+            color: "#94a3b8",
+            textAlign: "center",
+            maxWidth: "750px",
+            lineHeight: 1.4,
+            marginBottom: "36px",
+          }}
+        >
+          {subtitle}
+        </div>
+
+        {/* CTA pill */}
+        <div
+          style={{
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a)",
+            color: "#1a0f00",
+            fontSize: "18px",
+            fontWeight: "800",
+            padding: "14px 40px",
+            borderRadius: "100px",
+            letterSpacing: "0.5px",
+          }}
+        >
+          Download Free — No Purchase Required
+        </div>
+
+        {/* Branding */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "15px",
+            color: "#e2b714",
+            fontWeight: "600",
+            opacity: 0.8,
+          }}
+        >
+          AI Native Playbook Series
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -32,12 +32,16 @@ export async function generateMetadata({
         "Get a free guide that shows you how to use AI to automate 6 proven business frameworks. Instant PDF download.",
       type: "website",
       url: canonicalUrl,
+      siteName: "AI Native Playbook Series",
+      locale: locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US",
       images: [
         {
-          url: `${SITE_URL}/opengraph-image`,
+          url: locale === "en"
+            ? `${SITE_URL}/free-guide/opengraph-image`
+            : `${SITE_URL}/${locale}/free-guide/opengraph-image`,
           width: 1200,
           height: 630,
-          alt: "Free AI Business Automation Starter Guide",
+          alt: "Free AI Business Guide - AI Native Playbook",
         },
       ],
     },
@@ -46,7 +50,11 @@ export async function generateMetadata({
       title: "Free AI Business Automation Starter Guide",
       description:
         "Get a free guide that shows you how to use AI to automate 6 proven business frameworks. Instant PDF download.",
-      images: [`${SITE_URL}/opengraph-image`],
+      images: [
+        locale === "en"
+          ? `${SITE_URL}/free-guide/opengraph-image`
+          : `${SITE_URL}/${locale}/free-guide/opengraph-image`,
+      ],
     },
     robots: {
       index: true,

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -98,7 +98,7 @@ export default async function Image({ params }: { params: { locale: string } }) 
             fontWeight: "600",
           }}
         >
-          ai-driven-architect.com
+          AI Native Playbook Series
         </div>
       </div>
     ),

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -66,7 +66,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       siteName: "AI Native Playbook Series",
       images: [
         {
-          url: `${siteUrl}/og-image`,
+          url: `${siteUrl}/opengraph-image`,
           width: 1200,
           height: 630,
           alt: "AI Native Playbook Series — 6 AI-Powered Business Frameworks",
@@ -77,7 +77,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       card: "summary_large_image",
       title: meta.title,
       description: meta.twitterDescription,
-      images: [`${siteUrl}/og-image`],
+      images: [`${siteUrl}/opengraph-image`],
     },
     alternates: {
       canonical: canonicalUrl,


### PR DESCRIPTION
## Summary

- Add `/free-guide/opengraph-image.tsx`: dedicated gold-gradient OG image with "FREE GUIDE" badge for the lead magnet page
- Add `/blog/opengraph-image.tsx`: dedicated dark/blue OG image for blog index page, with topic pills (AI Marketing, Sales Funnels, etc.)
- Fix `/blog/[slug]/opengraph-image.tsx`: update branding label from `ai-driven-architect.com` to `AI Native Playbook Series`
- Fix `/[locale]/opengraph-image.tsx`: same branding fix (was still showing old domain)
- Fix `/[locale]/page.tsx`: correct OG image path from `/og-image` to `/opengraph-image` (path inconsistency with layout.tsx)
- Update `/blog/[slug]/page.tsx`: metadata and JSON-LD now reference the per-post dynamic OG image at `/blog/[slug]/opengraph-image` instead of the generic site OG
- Update `/blog/page.tsx`: metadata references `/blog/opengraph-image` instead of generic
- Update `/free-guide/page.tsx`: metadata references `/free-guide/opengraph-image` instead of generic

## Test plan

- [ ] Build passes with no TypeScript errors (`npm run build` verified clean)
- [ ] All 4 OG image routes confirmed in build output: `/[locale]/opengraph-image`, `/[locale]/blog/opengraph-image`, `/[locale]/blog/[slug]/opengraph-image`, `/[locale]/free-guide/opengraph-image`
- [ ] Verify `/free-guide` page social share preview shows gold FREE GUIDE OG image
- [ ] Verify `/blog` page social share preview shows blue blog OG image
- [ ] Verify individual blog post social share preview shows post title dynamically rendered
- [ ] Confirm homepage no longer references `/og-image` path (broken reference fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)