### PR TITLE
[ai-architect] meta description 최적화 — 6페이지+2블로그 120-155자 CTA 포함

### DIFF
--- a/content/blog/ai-architectural-rendering-step-by-step.md
+++ b/content/blog/ai-architectural-rendering-step-by-step.md
@@ -1,6 +1,6 @@
 ---
 title: "How to Create Stunning Architectural Renders with AI — Step by Step"
-description: "Step-by-step: create professional architectural renders with AI tools. Complete workflow from model preparation to final output for architects and designers."
+description: "Step-by-step guide to creating professional architectural renders with AI tools — from model preparation to final output for architects and designers."
 date: "2026-03-07"
 category: "Architecture & Design"
 tags: ["AI architectural rendering", "AI render tutorial", "architectural visualization", "AI rendering workflow", "design technology"]

--- a/content/blog/ai-in-architecture-design-better-buildings.md
+++ b/content/blog/ai-in-architecture-design-better-buildings.md
@@ -1,6 +1,6 @@
 ---
 title: "AI in Architecture: How Architects Are Using AI to Design Better Buildings"
-description: "How architects use AI to streamline design workflows, optimize building performance, and create innovative structures — a practical guide for architecture pros."
+description: "How architects use AI to streamline design workflows, optimize building performance, and create innovative structures — a practical guide."
 date: "2026-03-07"
 category: "Architecture & Design"
 tags: ["AI architecture", "AI building design", "AI for architects", "generative design", "architectural technology"]

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -11,8 +11,8 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architec
 const blogMeta: Record<string, { title: string; description: string; ogDescription: string }> = {
   en: {
     title: "AI Business Automation Blog | AI Native Playbook Series",
-    description: "Practical guides on AI business automation, AI marketing playbook strategies, and AI agent skills. Free frameworks for entrepreneurs building AI-native businesses.",
-    ogDescription: "Free AI business automation guides, AI marketing playbook strategies, and AI agent skills for entrepreneurs who want to scale with AI-powered frameworks.",
+    description: "AI business automation guides, marketing playbook strategies, and prompt frameworks. Free resources for entrepreneurs building AI-native businesses. Read.",
+    ogDescription: "Free AI business automation guides, marketing playbook strategies, and prompt frameworks for entrepreneurs scaling with AI-powered systems.",
   },
   ko: {
     title: "AI 비즈니스 블로그 | AI Native Playbook Series",

--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -22,14 +22,14 @@ export async function generateMetadata({
   return {
     title: "Free AI Business Automation Starter Guide",
     description:
-      "Download your free AI starter guide. Learn how to automate marketing funnels, sales copy, and product launches using AI. No purchase required.",
+      "Free AI Starter Guide: automate marketing funnels, sales copy, and product launches with AI. No purchase required — instant PDF download, start today.",
     alternates: {
       canonical: canonicalUrl,
     },
     openGraph: {
       title: "Free AI Business Automation Starter Guide",
       description:
-        "Get a free guide that shows you how to use AI to automate 6 proven business frameworks. Instant PDF download.",
+        "Get your free guide and learn to automate marketing funnels, sales copy, and product launches with AI. Instant PDF download — no purchase required.",
       type: "website",
       url: canonicalUrl,
       siteName: "AI Native Playbook Series",
@@ -49,7 +49,7 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: "Free AI Business Automation Starter Guide",
       description:
-        "Get a free guide that shows you how to use AI to automate 6 proven business frameworks. Instant PDF download.",
+        "Free guide: automate marketing funnels, sales copy, and product launches with AI. Instant PDF download — no purchase required.",
       images: [
         locale === "en"
           ? `${SITE_URL}/free-guide/opengraph-image`

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata({
       template: "%s | AI Native Playbook Series",
     },
     description:
-      "Turn Russell Brunson, Jeff Walker, Jim Edwards, and Nicolas Cole's proven frameworks into AI-powered business automation systems. 6 AI native PDF guides + prompt skills. Bundle $47.",
+      "Turn world-class marketing frameworks into AI automation systems. 6 AI-native PDF guides + prompt skills for entrepreneurs. Start executing — bundle $47.",
     keywords: [
       "AI business automation",
       "AI marketing playbook",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,7 +13,7 @@ import { getTranslations } from "next-intl/server";
 const homeMeta: Record<string, { title: string; description: string; ogDescription: string; twitterDescription: string }> = {
   en: {
     title: "AI Native Playbook Series — Business Automation with AI. 6 World-Class Frameworks.",
-    description: "6 AI-powered PDF guides that turn Russell Brunson, Jeff Walker, and Jim Edwards' frameworks into business automation systems. AI native guide + agent skills. Bundle $47, individual $17.",
+    description: "6 AI-powered guides that run Russell Brunson, Jeff Walker, Jim Edwards frameworks as automation systems. Bundle $47 — start your AI-native business today.",
     ogDescription: "6 AI native guides turn world-class business frameworks into executable automation systems. AI marketing playbook + agent skills. Bundle: $47.",
     twitterDescription: "Business automation with AI. 6 PDF guides turn Russell Brunson, Jeff Walker, Jim Edwards frameworks into AI-powered systems. Bundle $47.",
   },

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -15,10 +15,10 @@ export function generateMetadata(): Metadata {
   return {
     title: "AI Architecture Patterns | AI Native Playbook",
     description:
-      "Proven business frameworks automated with AI. Value Ladder, Mass Movement, Dream 100, Story-Driven Copy, and Product Launch patterns.",
+      "5 proven business frameworks automated with AI — Value Ladder, Mass Movement, Dream 100, Story Copy, Product Launch. Free to use. Start executing now.",
     openGraph: {
       title: "AI Architecture Patterns | AI Native Playbook",
-      description: "5 proven business frameworks automated with AI.",
+      description: "5 proven business frameworks automated with AI — Value Ladder, Mass Movement, Dream 100, Story Copy, and Product Launch. Free to use.",
       url: `${BASE_URL}/patterns`,
       type: "website",
       images: [{ url: `${BASE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Architecture Patterns" }],

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -9,7 +9,7 @@ import { getTranslations } from "next-intl/server";
 const productsMeta: Record<string, { title: string; description: string; ogDescription: string }> = {
   en: {
     title: "All 6 AI Business Automation Guides — AI Native Playbook Series",
-    description: "6 AI native business guides that turn Russell Brunson, Jeff Walker, Jim Edwards, and Nicolas Cole's frameworks into business automation with AI. AI marketing playbook + agent skills. $17 each or $47 bundle.",
+    description: "6 AI-native guides turning world-class marketing frameworks into executable AI systems. Prompt skills included — $17 each or $47 complete bundle.",
     ogDescription: "6 AI-powered business automation guides. Apply world-class marketing frameworks with AI agent skills. Individual $17 or complete bundle $47.",
   },
   ko: {


### PR DESCRIPTION
## Summary
- 6개 페이지 meta description 120-155자 범위로 최적화
- 2개 블로그 포스트 description 단축
- CTA 포함 클릭 유도 문구 추가
- ko/ja 콘텐츠는 현행 유지

## Test plan
- [ ] SERP preview에서 잘림 없이 표시되는지 확인
- [ ] OG/Twitter description 정합성

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post descriptions for improved clarity and consistency.
  * Refined metadata descriptions across key pages to better highlight product benefits and features.
  * Enhanced product and guide descriptions with more benefit-focused language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->