### PR TITLE
[ai-architect] canonical URL + hreflang 수정 — 중복 제거 및 누락 추가

### DIFF
--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -25,6 +25,11 @@ export async function generateMetadata({
       "Free AI Starter Guide: automate marketing funnels, sales copy, and product launches with AI. No purchase required — instant PDF download, start today.",
     alternates: {
       canonical: canonicalUrl,
+      languages: {
+        en: `${SITE_URL}/free-guide`,
+        ja: `${SITE_URL}/ja/free-guide`,
+        "x-default": `${SITE_URL}/free-guide`,
+      },
     },
     openGraph: {
       title: "Free AI Business Automation Starter Guide",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -205,12 +205,6 @@ export default async function LocaleLayout({
     getTranslations({ locale, namespace: "scrollBanner" }),
   ]);
 
-  const hreflangLinks = routing.locales.map((loc) => ({
-    rel: "alternate" as const,
-    hrefLang: loc,
-    href: loc === routing.defaultLocale ? SITE_URL : `${SITE_URL}/${loc}`,
-  }));
-
   const siteJsonLd = buildSiteJsonLd(locale, SITE_URL);
 
   return (
@@ -219,10 +213,6 @@ export default async function LocaleLayout({
         <link rel="manifest" href="/manifest.json" />
         <meta name="naver-site-verification" content="a6ff1a6273de52eee09a6d7965035cb60726a641" />
         <meta name="naver-site-verification" content="cda8874de26392058a4eacc1de62c73bf59ff7ef" />
-        {hreflangLinks.map((link) => (
-          <link key={link.hrefLang} rel={link.rel} hrefLang={link.hrefLang} href={link.href} />
-        ))}
-        <link rel="alternate" hrefLang="x-default" href={SITE_URL} />
         <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
         {process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN && (

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -25,6 +25,11 @@ export function generateMetadata(): Metadata {
     },
     alternates: {
       canonical: `${BASE_URL}/patterns`,
+      languages: {
+        en: `${BASE_URL}/patterns`,
+        ja: `${BASE_URL}/ja/patterns`,
+        "x-default": `${BASE_URL}/patterns`,
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary
- layout.tsx JSX 중복 hreflang 출력 제거 (generateMetadata와 충돌)
- patterns, free-guide 페이지에 hreflang languages 추가
- thank-you 등 noindex 페이지는 현행 유지

## Test plan
- [ ] Google Rich Results Test로 hreflang 확인
- [ ] 각 페이지 view-source에서 canonical 태그 단일 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced search engine recognition of language-specific content variants by updating how alternate language URLs are specified in metadata, supporting English, Japanese, and default language options across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->