### PR TITLE
[ai-architect] GA4 전환 이벤트 추적 — free-guide generate_lead 추가

### DIFF
--- a/src/app/[locale]/free-guide/thank-you/page.tsx
+++ b/src/app/[locale]/free-guide/thank-you/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
+import { GA4LeadComplete } from "@/components/GA4PurchaseComplete";
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com";
@@ -43,6 +44,8 @@ export default async function ThankYouPage({
 
   return (
     <div className="min-h-screen pt-24 pb-20">
+      {/* GA4: fire lead conversion event when thank-you page is viewed */}
+      <GA4LeadComplete source="free-guide-thank-you" />
       <section className="text-center max-w-2xl mx-auto px-4">
         {/* Success icon */}
         <div className="w-20 h-20 bg-gold/10 border border-gold/20 rounded-full flex items-center justify-center mx-auto mb-6">

--- a/src/components/FreeGuideForm.tsx
+++ b/src/components/FreeGuideForm.tsx
@@ -3,6 +3,13 @@
 import { useState, type FormEvent } from "react";
 import { useRouter, useParams } from "next/navigation";
 
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    fbq?: (...args: unknown[]) => void;
+  }
+}
+
 interface FreeGuideFormProps {
   ctaLabel?: string;
 }
@@ -22,6 +29,13 @@ export default function FreeGuideForm({ ctaLabel }: FreeGuideFormProps) {
     setError("");
     setLoading(true);
 
+    // GA4: form submit attempt (generate_lead is a recommended GA4 event)
+    window.gtag?.("event", "generate_lead", {
+      event_category: "lead",
+      event_label: "free_guide_form",
+      source: "free-guide-page",
+    });
+
     try {
       const res = await fetch("/api/subscribe-guide", {
         method: "POST",
@@ -33,12 +47,31 @@ export default function FreeGuideForm({ ctaLabel }: FreeGuideFormProps) {
 
       if (!res.ok) {
         setError(data.error || "Something went wrong. Please try again.");
+        window.gtag?.("event", "form_error", {
+          event_category: "lead",
+          event_label: "free_guide_form",
+          error_message: data.error ?? "unknown",
+        });
         return;
       }
+
+      // GA4: successful free guide lead capture
+      window.gtag?.("event", "free_guide_signup", {
+        event_category: "lead",
+        event_label: "free_guide_form",
+        source: "free-guide-page",
+      });
+      // Meta Pixel: Lead event
+      window.fbq?.("track", "Lead", { content_name: "free_guide" });
 
       router.push(`/${locale}/free-guide/thank-you`);
     } catch {
       setError("Network error. Please check your connection and try again.");
+      window.gtag?.("event", "form_error", {
+        event_category: "lead",
+        event_label: "free_guide_form",
+        error_message: "network_error",
+      });
     } finally {
       setLoading(false);
     }

--- a/src/components/GA4PurchaseComplete.tsx
+++ b/src/components/GA4PurchaseComplete.tsx
@@ -18,3 +18,14 @@ export function GA4PurchaseComplete({ productName }: { productName: string }) {
 
   return null;
 }
+
+export function GA4LeadComplete({ source }: { source: string }) {
+  useEffect(() => {
+    window.gtag?.("event", "free_guide_download_page_view", {
+      event_category: "lead",
+      event_label: source,
+    });
+  }, [source]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- FreeGuideForm에 generate_lead + free_guide_signup 이벤트 추가
- free-guide/thank-you에 페이지뷰 전환 이벤트 추가
- Meta Pixel Lead 이벤트 동시 발화
- 기존 BuyButton/CTA/EmailCapture 이벤트는 정상 확인

## Test plan
- [ ] /en/free-guide 폼 제출 시 GA4 Realtime에서 generate_lead 확인
- [ ] /en/free-guide/thank-you 도달 시 이벤트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced analytics tracking for the free guide signup journey, capturing key user interactions including form submissions, validation errors, and signup completions on the confirmation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->