### PR TITLE
fix(seo): add explicit robots metadata to blog pages

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -74,6 +74,17 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
         "x-default": canonicalUrl,
       },
     },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large" as const,
+        "max-snippet": -1,
+      },
+    },
   };
 }
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -85,6 +85,17 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
           : `${SITE_URL}/${locale}/blog/opengraph-image`,
       ],
     },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large" as const,
+        "max-snippet": -1,
+      },
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Add explicit `robots: { index: true, follow: true }` metadata to blog post pages (`/en/blog/[slug]`) and blog index page (`/en/blog`)
- Includes googleBot directives for max-video-preview, max-image-preview, and max-snippet
- Resolves noindex bug where blog posts had `<meta name="robots" content="noindex"/>` injected

## Files changed
- `src/app/[locale]/blog/[slug]/page.tsx` — added robots property to generateMetadata return
- `src/app/[locale]/blog/page.tsx` — added robots property to generateMetadata return

## Test plan
- [ ] Verify blog post pages no longer have `noindex` meta tag
- [ ] Verify blog index page renders correctly
- [ ] Check that `<meta name="robots" content="index, follow">` appears in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced search engine indexing configuration for all blog pages. Updated settings optimize how search engines discover, crawl, and display blog content in search results, with specific controls for image previews and snippet displays. These configuration updates improve blog content visibility and discoverability in search while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->