### PR TITLE
test: [ai-architect] add blog/products/routing/robots test coverage

### DIFF
--- a/src/__tests__/blog.test.ts
+++ b/src/__tests__/blog.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAllPosts,
+  getPostBySlug,
+  getPostsByCategory,
+  getAllCategories,
+  getAllTags,
+} from "@/lib/blog";
+
+describe("Blog", () => {
+  it("getAllPosts returns an array", () => {
+    const posts = getAllPosts();
+    expect(Array.isArray(posts)).toBe(true);
+  });
+
+  it("getAllPosts returns non-empty array (content/blog has .md files)", () => {
+    const posts = getAllPosts();
+    expect(posts.length).toBeGreaterThan(0);
+  });
+
+  it("posts are sorted by date descending", () => {
+    const posts = getAllPosts();
+    for (let i = 1; i < posts.length; i++) {
+      const prev = new Date(posts[i - 1].date).getTime();
+      const curr = new Date(posts[i].date).getTime();
+      expect(prev).toBeGreaterThanOrEqual(curr);
+    }
+  });
+
+  it("all posts have required fields", () => {
+    const posts = getAllPosts();
+    for (const post of posts) {
+      expect(post.slug).toBeTruthy();
+      expect(post.title).toBeTruthy();
+      expect(typeof post.description).toBe("string");
+      expect(typeof post.date).toBe("string");
+      expect(Array.isArray(post.tags)).toBe(true);
+      expect(typeof post.category).toBe("string");
+      expect(typeof post.readingTime).toBe("string");
+    }
+  });
+
+  it("getPostBySlug finds a known post", () => {
+    const posts = getAllPosts();
+    if (posts.length === 0) return;
+    const slug = posts[0].slug;
+    const post = getPostBySlug(slug);
+    expect(post).not.toBeNull();
+    expect(post!.slug).toBe(slug);
+    expect(typeof post!.content).toBe("string");
+    expect(post!.content.length).toBeGreaterThan(0);
+  });
+
+  it("getPostBySlug returns null for invalid slug", () => {
+    const post = getPostBySlug("this-slug-definitely-does-not-exist-xyz");
+    expect(post).toBeNull();
+  });
+
+  it("getPostBySlug returns content field (not in getAllPosts)", () => {
+    const posts = getAllPosts();
+    if (posts.length === 0) return;
+    const full = getPostBySlug(posts[0].slug);
+    expect(full).toHaveProperty("content");
+    // getAllPosts omits content
+    expect(posts[0]).not.toHaveProperty("content");
+  });
+
+  it("getAllCategories returns sorted array of strings", () => {
+    const categories = getAllCategories();
+    expect(Array.isArray(categories)).toBe(true);
+    for (const cat of categories) {
+      expect(typeof cat).toBe("string");
+    }
+    const sorted = [...categories].sort();
+    expect(categories).toEqual(sorted);
+  });
+
+  it("getAllTags returns at most 10 tags", () => {
+    const tags = getAllTags();
+    expect(Array.isArray(tags)).toBe(true);
+    expect(tags.length).toBeLessThanOrEqual(10);
+    for (const tag of tags) {
+      expect(typeof tag).toBe("string");
+    }
+  });
+
+  it("getPostsByCategory filters correctly", () => {
+    const categories = getAllCategories();
+    if (categories.length === 0) return;
+    const cat = categories[0];
+    const filtered = getPostsByCategory(cat);
+    expect(filtered.length).toBeGreaterThan(0);
+    for (const post of filtered) {
+      expect(post.category).toBe(cat);
+    }
+  });
+
+  it("getPostsByCategory returns empty array for unknown category", () => {
+    const filtered = getPostsByCategory("__nonexistent_category__");
+    expect(filtered).toEqual([]);
+  });
+});

--- a/src/__tests__/products.test.ts
+++ b/src/__tests__/products.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  books,
+  bundle,
+  getBookBySlug,
+  getBundleUrl,
+  getProductUrl,
+  getBundlePaddlePriceId,
+  getBookPaddlePriceId,
+  BUNDLE_PADDLE_PRICE_ENV_KEY,
+} from "@/lib/products";
+
+describe("Products — books catalog", () => {
+  it("books array has 6 volumes", () => {
+    expect(books).toHaveLength(6);
+  });
+
+  it("every book has required fields", () => {
+    for (const book of books) {
+      expect(book.id).toBeTruthy();
+      expect(book.slug).toBeTruthy();
+      expect(book.vol).toBeGreaterThanOrEqual(1);
+      expect(book.title).toBeTruthy();
+      expect(book.subtitle).toBeTruthy();
+      expect(book.tagline).toBeTruthy();
+      expect(book.shortDescription).toBeTruthy();
+      expect(book.framework).toBeTruthy();
+      expect(book.sourceBook).toBeTruthy();
+      expect(book.icon).toBeTruthy();
+      expect(book.color).toBeTruthy();
+      expect(book.envKey).toBeTruthy();
+      expect(book.paddlePriceEnvKey).toBeTruthy();
+      expect(book.highlights.length).toBeGreaterThan(0);
+      expect(book.caseStudy.result).toBeTruthy();
+      expect(book.caseStudy.detail).toBeTruthy();
+      expect(book.frameworks.length).toBeGreaterThan(0);
+      expect(book.whatsInside.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all slugs are unique", () => {
+    const slugs = books.map((b) => b.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("getBookBySlug finds existing book", () => {
+    const book = getBookBySlug("ai-marketing-architect");
+    expect(book).toBeDefined();
+    expect(book!.vol).toBe(1);
+  });
+
+  it("getBookBySlug returns undefined for invalid slug", () => {
+    expect(getBookBySlug("nonexistent-book")).toBeUndefined();
+  });
+});
+
+describe("Products — bundle", () => {
+  it("bundle has correct structure", () => {
+    expect(bundle.title).toBeTruthy();
+    expect(bundle.subtitle).toBeTruthy();
+    expect(bundle.price).toBeGreaterThan(0);
+    expect(bundle.originalPrice).toBeGreaterThan(bundle.price);
+    expect(bundle.discount).toBeGreaterThan(0);
+    expect(bundle.envKey).toBeTruthy();
+  });
+});
+
+describe("Products — URL helpers", () => {
+  it("getBundleUrl returns '#' when env is unset", () => {
+    const url = getBundleUrl();
+    expect(url).toBe("#");
+  });
+
+  it("getProductUrl returns '#' when env is unset", () => {
+    const url = getProductUrl("NEXT_PUBLIC_LS_PRODUCT_1_URL");
+    expect(url).toBe("#");
+  });
+
+  it("getProductUrl builds redirect URL when env is set", () => {
+    vi.stubEnv("NEXT_PUBLIC_LS_PRODUCT_1_URL", "https://store.example.com/buy/1");
+    const url = getProductUrl("NEXT_PUBLIC_LS_PRODUCT_1_URL");
+    expect(url).toContain("https://store.example.com/buy/1");
+    expect(url).toContain("checkout[custom][redirect_url]");
+    expect(url).toContain("thank-you");
+    vi.unstubAllEnvs();
+  });
+
+  it("getBundleUrl builds redirect URL when env is set", () => {
+    vi.stubEnv("NEXT_PUBLIC_LS_BUNDLE_URL", "https://store.example.com/buy/bundle");
+    const url = getBundleUrl();
+    expect(url).toContain("https://store.example.com/buy/bundle");
+    expect(url).toContain("checkout[custom][redirect_url]");
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("Products — Paddle helpers", () => {
+  it("getBundlePaddlePriceId returns undefined when env is unset", () => {
+    expect(getBundlePaddlePriceId()).toBeUndefined();
+  });
+
+  it("getBundlePaddlePriceId returns value when env is set", () => {
+    vi.stubEnv(BUNDLE_PADDLE_PRICE_ENV_KEY, "pri_test_123");
+    expect(getBundlePaddlePriceId()).toBe("pri_test_123");
+    vi.unstubAllEnvs();
+  });
+
+  it("getBookPaddlePriceId returns value from env", () => {
+    vi.stubEnv("PADDLE_PRICE_ID_VOL1", "pri_vol1_test");
+    expect(getBookPaddlePriceId("PADDLE_PRICE_ID_VOL1")).toBe("pri_vol1_test");
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/__tests__/robots.test.ts
+++ b/src/__tests__/robots.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import robots from "@/app/robots";
+
+describe("Robots", () => {
+  const config = robots();
+
+  it("has rules array", () => {
+    expect(Array.isArray(config.rules)).toBe(true);
+    expect((config.rules as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("default rule allows / and disallows /api/", () => {
+    const rules = config.rules as Array<{
+      userAgent: string;
+      allow?: string | string[];
+      disallow?: string | string[];
+    }>;
+    const defaultRule = rules.find((r) => r.userAgent === "*");
+    expect(defaultRule).toBeDefined();
+    expect(defaultRule!.allow).toBe("/");
+    expect(defaultRule!.disallow).toContain("/api/");
+  });
+
+  it("blocks AI crawlers", () => {
+    const rules = config.rules as Array<{ userAgent: string; disallow?: string | string[] }>;
+    const aiCrawlers = ["GPTBot", "ChatGPT-User", "anthropic-ai", "ClaudeBot", "CCBot"];
+    for (const crawler of aiCrawlers) {
+      const rule = rules.find((r) => r.userAgent === crawler);
+      expect(rule, `Rule for ${crawler} should exist`).toBeDefined();
+      expect(rule!.disallow).toBe("/");
+    }
+  });
+
+  it("disallows /ko and /ko/ paths", () => {
+    const rules = config.rules as Array<{ userAgent: string; disallow?: string | string[] }>;
+    const defaultRule = rules.find((r) => r.userAgent === "*");
+    expect(defaultRule!.disallow).toContain("/ko");
+    expect(defaultRule!.disallow).toContain("/ko/");
+  });
+
+  it("includes sitemap URLs", () => {
+    expect(config.sitemap).toBeDefined();
+    const sitemaps = config.sitemap as string[];
+    expect(sitemaps.length).toBeGreaterThanOrEqual(1);
+    expect(sitemaps.some((s) => s.includes("sitemap.xml"))).toBe(true);
+  });
+});

--- a/src/__tests__/routing.test.ts
+++ b/src/__tests__/routing.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { routing } from "@/i18n/routing";
+
+describe("i18n Routing", () => {
+  it("locales includes en and ja", () => {
+    expect(routing.locales).toContain("en");
+    expect(routing.locales).toContain("ja");
+  });
+
+  it("locales does not include ko", () => {
+    expect(routing.locales).not.toContain("ko");
+  });
+
+  it("defaultLocale is en", () => {
+    expect(routing.defaultLocale).toBe("en");
+  });
+
+  it("locales array has exactly 2 entries", () => {
+    expect(routing.locales).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 33 new tests across 4 untested modules: blog, products, routing, robots
- blog.test.ts (11 tests): getAllPosts, getPostBySlug, categories, tags, date sorting, field validation
- products.test.ts (13 tests): catalog integrity, URL helpers with env stubbing, Paddle price ID helpers
- routing.test.ts (4 tests): i18n locales and defaultLocale config
- robots.test.ts (5 tests): default rules, AI crawler blocking, /ko disallow, sitemap URLs

## Test plan
- [x] All 33 new tests pass via `npx vitest run`
- [x] No existing tests broken (140 total pass; 1 pre-existing sitemap.test.ts import failure unrelated)
- [x] No source code modified — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for blog utilities including post retrieval, sorting, and filtering functionality.
  * Expanded test coverage for products module covering catalog validation and environment-based behavior.
  * Added test suite for robots.txt generation and AI crawler blocking logic.
  * Added test suite for internationalization routing configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->