### PR TITLE
[ai-architect] Blog email subscription funnel enhancement

### DIFF
--- a/src/__tests__/blog-inline-cta.test.ts
+++ b/src/__tests__/blog-inline-cta.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { splitContentAtMidpoint } from "@/lib/blog-content-utils";
+
+describe("splitContentAtMidpoint", () => {
+  it("splits content roughly in half by paragraph", () => {
+    const content = "Para 1\n\nPara 2\n\nPara 3\n\nPara 4";
+    const { before, after } = splitContentAtMidpoint(content);
+    expect(before.length).toBeGreaterThan(0);
+    expect(after.length).toBeGreaterThan(0);
+  });
+
+  it("returns full content in before when content has no paragraphs to split", () => {
+    const content = "Single line";
+    const { before, after } = splitContentAtMidpoint(content);
+    expect(before).toBe(content);
+    expect(after).toBe("");
+  });
+
+  it("splits at approximately 40-60% of paragraphs", () => {
+    const paragraphs = Array.from({ length: 10 }, (_, i) => `Paragraph ${i + 1}`);
+    const content = paragraphs.join("\n\n");
+    const { before, after } = splitContentAtMidpoint(content);
+
+    const beforeParaCount = before.split("\n\n").filter(Boolean).length;
+    const totalParaCount = paragraphs.length;
+    const splitRatio = beforeParaCount / totalParaCount;
+
+    expect(splitRatio).toBeGreaterThanOrEqual(0.3);
+    expect(splitRatio).toBeLessThanOrEqual(0.7);
+    expect(after.length).toBeGreaterThan(0);
+  });
+
+  it("handles content with headings and code blocks correctly", () => {
+    const content = [
+      "# Heading 1",
+      "Paragraph under heading 1.",
+      "## Heading 2",
+      "Paragraph under heading 2.",
+      "```js\nconst x = 1;\n```",
+      "### Heading 3",
+      "Paragraph under heading 3.",
+      "More content here.",
+    ].join("\n\n");
+
+    const { before, after } = splitContentAtMidpoint(content);
+    const combined = before + (after ? "\n\n" + after : "");
+    // All original content is preserved (whitespace may differ at join)
+    expect(combined.replace(/\s+/g, " ").trim()).toBe(
+      content.replace(/\s+/g, " ").trim()
+    );
+  });
+
+  it("does not split very short content (less than 4 paragraphs)", () => {
+    const content = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+    const { before, after } = splitContentAtMidpoint(content);
+    expect(before).toBe(content);
+    expect(after).toBe("");
+  });
+
+  it("preserves all content across before and after", () => {
+    const paragraphs = Array.from({ length: 8 }, (_, i) => `Paragraph ${i + 1} content here.`);
+    const content = paragraphs.join("\n\n");
+    const { before, after } = splitContentAtMidpoint(content);
+
+    const reconstructed = [before, after].filter(Boolean).join("\n\n");
+    expect(reconstructed).toBe(content);
+  });
+});

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getPostBySlug, getAllPosts, getRelatedPosts } from "@/lib/blog";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Link from "next/link";
 import Image from "next/image";
@@ -9,6 +10,8 @@ import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import { books } from "@/lib/products";
+import BlogInlineCTA from "@/components/BlogInlineCTA";
+import { splitContentAtMidpoint } from "@/lib/blog-content-utils";
 
 export function generateStaticParams() {
   const posts = getAllPosts();
@@ -202,32 +205,50 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
           <p className="text-lg text-text-secondary">{post.description}</p>
         </header>
-        <div className="prose prose-invert prose-gold max-w-none">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              img: ({ src, alt }) => {
-                const srcStr = typeof src === 'string' ? src : '';
-                const fallbackAlt = srcStr ? srcStr.split('/').pop()?.replace(/[-_]/g, ' ').replace(/\.\w+$/, '') || 'article image' : 'article image';
-                if (!srcStr) return null;
-                return (
-                  <span className="block relative w-full my-6" style={{ aspectRatio: '16/9' }}>
-                    <Image
-                      src={srcStr}
-                      alt={alt || fallbackAlt}
-                      fill
-                      sizes="(max-width: 768px) 100vw, 700px"
-                      className="object-contain rounded-lg"
-                      loading="lazy"
-                    />
-                  </span>
-                );
-              },
-            }}
-          >
-            {post.content}
-          </ReactMarkdown>
-        </div>
+        {(() => {
+          const { before, after } = splitContentAtMidpoint(post.content);
+          const markdownComponents: Components = {
+            img: ({ src, alt }) => {
+              const srcStr = typeof src === "string" ? src : "";
+              const fallbackAlt = srcStr
+                ? srcStr.split("/").pop()?.replace(/[-_]/g, " ").replace(/\.\w+$/, "") || "article image"
+                : "article image";
+              if (!srcStr) return null;
+              return (
+                <span className="block relative w-full my-6" style={{ aspectRatio: "16/9" }}>
+                  <Image
+                    src={srcStr}
+                    alt={alt || fallbackAlt}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 700px"
+                    className="object-contain rounded-lg"
+                    loading="lazy"
+                  />
+                </span>
+              );
+            },
+          };
+
+          return (
+            <>
+              <div className="prose prose-invert prose-gold max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                  {before}
+                </ReactMarkdown>
+              </div>
+
+              {after && <BlogInlineCTA locale={locale} />}
+
+              {after && (
+                <div className="prose prose-invert prose-gold max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                    {after}
+                  </ReactMarkdown>
+                </div>
+              )}
+            </>
+          );
+        })()}
       </article>
       {/* Product CTA */}
       <div className="mt-12 p-6 bg-gradient-to-r from-gold/10 to-gold/5 border border-gold/20 rounded-2xl">
@@ -279,7 +300,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           <div className="flex items-start gap-3 mb-3">
             <div className="shrink-0 w-9 h-9 bg-gold/20 border border-gold/30 rounded-xl flex items-center justify-center mt-0.5">
               <svg className="w-5 h-5 text-gold" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0-3-3m3 3 3-3m2 8H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z" />
               </svg>
             </div>
             <div className="flex-1 min-w-0">

--- a/src/components/BlogInlineCTA.tsx
+++ b/src/components/BlogInlineCTA.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+interface BlogInlineCTAProps {
+  locale?: string;
+}
+
+/**
+ * Inline CTA banner for blog posts — Hook-Story-Offer principle.
+ * Inserted at approximately the midpoint of blog post content.
+ * Links to /free-guide page for email capture.
+ */
+export default function BlogInlineCTA({ locale = "en" }: BlogInlineCTAProps) {
+  const freeGuideHref = locale === "en" ? "/free-guide" : `/${locale}/free-guide`;
+
+  return (
+    <div
+      className="my-8 rounded-2xl border border-gold/25 bg-gradient-to-r from-gold/10 to-gold/5 p-6 not-prose"
+      role="complementary"
+      aria-label="Free guide offer"
+    >
+      {/* Hook */}
+      <p className="text-base font-bold text-gold leading-snug mb-2">
+        Stop reading about AI. Start running it.
+      </p>
+
+      {/* Story */}
+      <p className="text-sm text-text-secondary leading-relaxed mb-4">
+        Most entrepreneurs spend hours researching AI strategies — then never implement them.
+        This free guide gives you the exact system prompts and frameworks to put AI to work{" "}
+        <em>today</em>.
+      </p>
+
+      {/* Offer */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+        <Link
+          href={freeGuideHref}
+          className="inline-flex items-center gap-2 rounded-xl bg-gold px-5 py-2.5 text-sm font-bold text-navy-dark transition-colors hover:bg-gold-light focus:outline-none focus:ring-2 focus:ring-gold/60"
+        >
+          <svg
+            className="h-4 w-4 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 10v6m0 0-3-3m3 3 3-3m2 8H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2z"
+            />
+          </svg>
+          Get the Free AI Starter Guide
+        </Link>
+        <span className="text-xs text-text-muted">Free · No spam · Instant download</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/blog-content-utils.ts
+++ b/src/lib/blog-content-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Utilities for splitting blog post content for inline CTA insertion.
+ */
+
+const MIN_PARAGRAPHS_TO_SPLIT = 4;
+const SPLIT_RATIO = 0.5; // target ~50% split point
+
+/**
+ * Splits markdown content into two halves at approximately the midpoint by paragraph.
+ * Returns { before, after } where after is empty string if content is too short to split.
+ */
+export function splitContentAtMidpoint(content: string): {
+  before: string;
+  after: string;
+} {
+  const paragraphs = content.split("\n\n");
+
+  if (paragraphs.length < MIN_PARAGRAPHS_TO_SPLIT) {
+    return { before: content, after: "" };
+  }
+
+  const splitIndex = Math.round(paragraphs.length * SPLIT_RATIO);
+  const before = paragraphs.slice(0, splitIndex).join("\n\n");
+  const after = paragraphs.slice(splitIndex).join("\n\n");
+
+  return { before, after };
+}


### PR DESCRIPTION
## Summary
- Add `BlogInlineCTA` component with Hook-Story-Offer principle, inserted at ~50% of blog post content
- Add `splitContentAtMidpoint` utility to split markdown content by paragraph for mid-article CTA placement
- Fix bottom free-guide CTA icon: replaced warning triangle with download arrow SVG
- All changes scoped to blog posts only (1-page-1-purpose rule respected — homepage untouched)

## Test plan
- [x] `npm run build` succeeds
- [x] All 168 tests pass (162 existing + 6 new for splitContentAtMidpoint)
- [x] BlogInlineCTA renders inline in blog posts at ~50% content point
- [x] Bottom CTA icon updated from warning to download icon
- [x] Inline CTA links to `/free-guide` (locale-aware)