### PR TITLE
feat(email): ai-driven-architect.com → ai-native-playbook.com 도메인 마이그레이션

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -33,7 +33,7 @@ export async function sendPurchaseConfirmationEmail(
   }
 
   const siteUrl =
-    (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com").trim();
+    (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
   const htmlContent = buildConfirmationEmailHtml(order, transactionId, siteUrl);
 
@@ -46,7 +46,7 @@ export async function sendPurchaseConfirmationEmail(
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-driven-architect.com",
+        email: "hello@ai-native-playbook.com",
       },
       to: [{ email: order.customerEmail, name: order.customerName || undefined }],
       subject: `Your ${order.productName} is ready to download`,
@@ -126,7 +126,7 @@ export function buildConfirmationEmailHtml(
 
     <hr style="border:none;border-top:1px solid #eee;margin:32px 0;" />
     <p style="color:#999;font-size:12px;text-align:center;margin:0;">
-      AI Native Playbook Series | ai-driven-architect.com
+      AI Native Playbook Series | ai-native-playbook.com
     </p>
   </div>
 </div>
@@ -153,7 +153,7 @@ export async function sendPaymentFailureEmail(
   }
 
   const siteUrl =
-    (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com").trim();
+    (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
   const res = await fetch("https://api.brevo.com/v3/smtp/email", {
     method: "POST",
@@ -164,7 +164,7 @@ export async function sendPaymentFailureEmail(
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-driven-architect.com",
+        email: "hello@ai-native-playbook.com",
       },
       to: [{ email: customerEmail, name: customerName || undefined }],
       subject: `Action needed: Payment issue for ${productName}`,
@@ -190,7 +190,7 @@ export async function sendPaymentFailureEmail(
     </p>
     <hr style="border:none;border-top:1px solid #eee;margin:32px 0;" />
     <p style="color:#999;font-size:12px;text-align:center;margin:0;">
-      AI Native Playbook Series | ai-driven-architect.com
+      AI Native Playbook Series | ai-native-playbook.com
     </p>
   </div>
 </div>

--- a/src/lib/onboarding-emails.ts
+++ b/src/lib/onboarding-emails.ts
@@ -21,11 +21,11 @@ const BRAND = {
 } as const;
 
 const siteUrl = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com"
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com"
 ).trim();
 
 const SENDER_NAME = "AI Native Playbook Series";
-const FOOTER_DOMAIN = "ai-driven-architect.com";
+const FOOTER_DOMAIN = "ai-native-playbook.com";
 
 /** Shared HTML wrapper used by every template. */
 function wrapHtml({


### PR DESCRIPTION
## Summary
- `src/lib/email.ts`: 모든 `ai-driven-architect.com` 참조를 `ai-native-playbook.com`으로 교체 (fallback URL 2건, sender email 2건, footer 2건)
- `src/lib/onboarding-emails.ts`: `siteUrl` fallback + `FOOTER_DOMAIN` 상수 교체 (2건)
- 환경변수 참조 코드(`process.env.NEXT_PUBLIC_SITE_URL`) 미변경

## Test plan
- [x] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)