### PR TITLE
feat(aeo): AI 크롤러 Allow + JSON-LD 보강 + llms.txt

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,88 @@
+# AI Native Playbook Series — Full Reference
+
+> 6 AI-powered PDF guides that turn proven business frameworks into executable AI architecture patterns. For entrepreneurs, marketers, and AI-native builders.
+
+## About
+AI Native Playbook Series bridges the gap between reading business books and executing the frameworks. Each guide transforms a world-class business methodology into an AI-automated system with step-by-step instructions and ready-to-use prompt templates. Works with ChatGPT, Claude, Gemini, and any LLM.
+
+## Products (Detailed)
+
+### Vol.1: DotCom Secrets AI
+- Based on: Russell Brunson's DotCom Secrets
+- What it does: Automates sales funnel creation, value ladder design, and traffic strategy using AI
+- Includes: 20+ prompt templates for funnel building, lead magnet creation, and upsell sequences
+- Price: $17
+
+### Vol.2: Product Launch Formula AI
+- Based on: Jeff Walker's Product Launch Formula (PLF)
+- What it does: Automates product launch sequences, pre-launch content, and email campaigns using AI
+- Includes: Complete AI-powered launch sequence templates, sideways sales letter prompts
+- Price: $17
+
+### Vol.3: Copywriting Secrets AI
+- Based on: Jim Edwards' Copywriting Secrets
+- What it does: Automates headline writing, sales copy, and email sequences using AI
+- Includes: 30+ copywriting prompt templates for headlines, bullets, stories, and CTAs
+- Price: $17
+
+### Vol.4: The Art and Business of Online Writing AI
+- Based on: Nicolas Cole's online writing system
+- What it does: Automates content creation, headline optimization, and audience building using AI
+- Includes: AI writing system for consistent content production and audience growth
+- Price: $17
+
+### Vol.5: AI Marketing Playbook
+- Comprehensive AI marketing automation system
+- What it does: Integrates marketing channels (SEO, email, social, ads) into AI-automated workflows
+- Includes: Marketing automation templates, analytics prompts, campaign optimization
+- Price: $17
+
+### Vol.6: AI Agent Skills
+- Build and deploy AI agents for business tasks
+- What it does: Teaches how to create specialized AI agents that handle business operations
+- Includes: Agent architecture patterns, tool use patterns, multi-agent coordination
+- Price: $17
+
+### Complete Bundle
+- All 6 guides included
+- Price: $47 (save $55 vs individual purchase)
+- Lifetime updates included
+
+## Frequently Asked Questions
+
+### What format are the guides?
+All guides are PDF digital downloads. You receive instant access after purchase.
+
+### Do I need technical skills?
+No. The guides are written for non-technical entrepreneurs. All AI interactions use natural language prompts.
+
+### Which AI tools do the guides work with?
+All guides work with ChatGPT (OpenAI), Claude (Anthropic), Gemini (Google), and any modern LLM.
+
+### What is the refund policy?
+30-day money-back guarantee. If the guides don't meet your expectations, email contact@newbizsoft.com for a full refund.
+
+### Are updates included?
+Yes. All guides include lifetime updates as AI capabilities evolve.
+
+## Key Facts
+- Website: https://ai-native-playbook.com
+- Publisher: NewBizSoft
+- Contact: contact@newbizsoft.com
+- Format: PDF digital download
+- Individual price: $17 per guide
+- Bundle price: $47 for all 6 guides
+- Languages: English, Korean, Japanese
+- Guarantee: 30-day money-back
+
+## Links
+- Homepage: https://ai-native-playbook.com
+- Products: https://ai-native-playbook.com/products
+- Bundle: https://ai-native-playbook.com/bundle
+- FAQ: https://ai-native-playbook.com/faq
+- About: https://ai-native-playbook.com/about
+- Blog: https://ai-native-playbook.com/blog
+- Free Guide: https://ai-native-playbook.com/free-guide
+- Privacy: https://ai-native-playbook.com/privacy
+- Terms: https://ai-native-playbook.com/terms
+- Refund Policy: https://ai-native-playbook.com/refund

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,30 @@
+# AI Native Playbook Series
+
+> 6 AI-powered PDF guides that turn proven business frameworks into executable AI architecture patterns. Bundle: $47.
+
+## What is AI Native Playbook?
+AI Native Playbook is a series of 6 digital guides (PDF) designed for entrepreneurs, marketers, and AI-native builders. Each guide transforms a world-class business framework into an AI-automated system with ready-to-use prompt templates.
+
+## Products
+- Vol.1: DotCom Secrets AI — Russell Brunson's funnel framework automated with AI
+- Vol.2: Product Launch Formula AI — Jeff Walker's launch system automated with AI
+- Vol.3: Copywriting Secrets AI — Jim Edwards' copywriting framework automated with AI
+- Vol.4: The Art and Business of Online Writing AI — Nicolas Cole's writing system automated with AI
+- Vol.5: AI Marketing Playbook — Comprehensive AI marketing automation system
+- Vol.6: AI Agent Skills — Build and deploy AI agents for business tasks
+- Complete Bundle (6 books): $47
+
+## Key Facts
+- Website: https://ai-native-playbook.com
+- Format: PDF digital download
+- Individual price: $17 per guide
+- Bundle price: $47 for all 6 guides
+- Languages: English, Korean, Japanese
+- Refund: 30-day money-back guarantee
+
+## Links
+- Products: https://ai-native-playbook.com/products
+- Bundle: https://ai-native-playbook.com/bundle
+- FAQ: https://ai-native-playbook.com/faq
+- About: https://ai-native-playbook.com/about
+- Blog: https://ai-native-playbook.com/blog

--- a/src/__tests__/robots.test.ts
+++ b/src/__tests__/robots.test.ts
@@ -3,6 +3,11 @@ import robots from "@/app/robots";
 
 describe("Robots", () => {
   const config = robots();
+  const rules = config.rules as Array<{
+    userAgent: string;
+    allow?: string | string[];
+    disallow?: string | string[];
+  }>;
 
   it("has rules array", () => {
     expect(Array.isArray(config.rules)).toBe(true);
@@ -10,38 +15,50 @@ describe("Robots", () => {
   });
 
   it("default rule allows / and disallows /api/", () => {
-    const rules = config.rules as Array<{
-      userAgent: string;
-      allow?: string | string[];
-      disallow?: string | string[];
-    }>;
     const defaultRule = rules.find((r) => r.userAgent === "*");
     expect(defaultRule).toBeDefined();
     expect(defaultRule!.allow).toBe("/");
     expect(defaultRule!.disallow).toContain("/api/");
   });
 
-  it("blocks AI crawlers", () => {
-    const rules = config.rules as Array<{ userAgent: string; disallow?: string | string[] }>;
-    const aiCrawlers = ["GPTBot", "ChatGPT-User", "anthropic-ai", "ClaudeBot", "CCBot"];
-    for (const crawler of aiCrawlers) {
-      const rule = rules.find((r) => r.userAgent === crawler);
-      expect(rule, `Rule for ${crawler} should exist`).toBeDefined();
-      expect(rule!.disallow).toBe("/");
+  it("allows AI crawlers explicitly (AEO)", () => {
+    const aiAllowBots = [
+      "GPTBot",
+      "OAI-SearchBot",
+      "ChatGPT-User",
+      "ClaudeBot",
+      "Claude-SearchBot",
+      "anthropic-ai",
+      "PerplexityBot",
+      "Google-Extended",
+      "Applebot-Extended",
+      "CCBot",
+      "cohere-ai",
+    ];
+    for (const bot of aiAllowBots) {
+      const rule = rules.find((r) => r.userAgent === bot);
+      expect(rule, `Rule for ${bot} should exist`).toBeDefined();
+      expect(rule!.allow, `${bot} should have allow: "/"`).toBe("/");
+      expect(rule!.disallow, `${bot} should NOT have disallow`).toBeUndefined();
     }
   });
 
+  it("blocks Bytespider", () => {
+    const rule = rules.find((r) => r.userAgent === "Bytespider");
+    expect(rule).toBeDefined();
+    expect(rule!.disallow).toBe("/");
+  });
+
   it("disallows /ko and /ko/ paths", () => {
-    const rules = config.rules as Array<{ userAgent: string; disallow?: string | string[] }>;
     const defaultRule = rules.find((r) => r.userAgent === "*");
     expect(defaultRule!.disallow).toContain("/ko");
     expect(defaultRule!.disallow).toContain("/ko/");
   });
 
-  it("includes sitemap URLs", () => {
+  it("includes 4 sitemap URLs", () => {
     expect(config.sitemap).toBeDefined();
     const sitemaps = config.sitemap as string[];
-    expect(sitemaps.length).toBeGreaterThanOrEqual(1);
+    expect(sitemaps).toHaveLength(4);
     expect(sitemaps.some((s) => s.includes("sitemap.xml"))).toBe(true);
   });
 });

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       canonical: canonicalUrl,
       languages: {
         en: `${siteUrl}/about`,
+        ko: `${siteUrl}/ko/about`,
         ja: `${siteUrl}/ja/about`,
         "x-default": `${siteUrl}/about`,
       },

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -165,6 +165,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     },
     keywords: post.tags.join(", "),
     wordCount: Math.round(post.content.split(/\s+/).length),
+    speakable: {
+      "@type": "SpeakableSpecification",
+      cssSelector: ["h1", "article p:first-of-type"],
+    },
   };
 
   const breadcrumbJsonLd = {

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -29,6 +29,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       canonical: canonicalUrl,
       languages: {
         en: `${SITE_URL}/faq`,
+        ko: `${SITE_URL}/ko/faq`,
         ja: `${SITE_URL}/ja/faq`,
         "x-default": `${SITE_URL}/faq`,
       },
@@ -147,6 +148,10 @@ export default async function FaqPage({ params }: { params: Promise<{ locale: st
         text: item.answer,
       },
     })),
+    speakable: {
+      "@type": "SpeakableSpecification",
+      cssSelector: ["h1", ".faq-answer"],
+    },
   };
 
   return (

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -161,9 +161,14 @@ function buildSiteJsonLd(locale: string, siteUrl: string) {
         "@type": "Organization",
         "@id": `${siteUrl}/#organization`,
         name: "AI Native Playbook Series",
-        legalName: "ai-architect",
+        legalName: "NewBizSoft",
         url: siteUrl,
         description: descriptions[locale] ?? descriptions.en,
+        foundingDate: "2024",
+        areaServed: "Worldwide",
+        sameAs: [
+          "https://ai-driven-architect.com",
+        ],
         logo: {
           "@type": "ImageObject",
           "@id": `${siteUrl}/#logo`,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -191,6 +191,10 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       { "@type": "Thing", name: "AI Architect" },
     ],
     keywords: "AI native playbook, AI architecture patterns, AI architect, business automation with AI, AI marketing playbook",
+    speakable: {
+      "@type": "SpeakableSpecification",
+      cssSelector: ["h1", ".hero-description", ".faq-section"],
+    },
   } : null;
 
   const bookListJsonLd = {

--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -143,7 +143,7 @@ export default async function ProductPage({ params }: Props) {
         availability: "https://schema.org/InStock",
         url: `${siteUrl}/products/${slug}`,
         priceValidUntil: "2026-12-31",
-        seller: { "@type": "Organization", name: "ai-architect", url: siteUrl },
+        seller: { "@type": "Organization", name: "AI Native Playbook Series", url: siteUrl },
       },
       {
         "@type": "Offer",
@@ -153,7 +153,7 @@ export default async function ProductPage({ params }: Props) {
         availability: "https://schema.org/InStock",
         url: `${siteUrl}/bundle`,
         priceValidUntil: "2026-12-31",
-        seller: { "@type": "Organization", name: "ai-architect", url: siteUrl },
+        seller: { "@type": "Organization", name: "AI Native Playbook Series", url: siteUrl },
       },
     ],
   };

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -21,34 +21,52 @@ export default function robots(): MetadataRoute.Robots {
         ],
         crawlDelay: 1,
       },
+      // AI crawlers — explicitly allowed (AEO optimization)
       {
         userAgent: "GPTBot",
-        disallow: "/",
+        allow: "/",
+      },
+      {
+        userAgent: "OAI-SearchBot",
+        allow: "/",
       },
       {
         userAgent: "ChatGPT-User",
-        disallow: "/",
-      },
-      {
-        userAgent: "Google-Extended",
-        disallow: "/",
-      },
-      {
-        userAgent: "CCBot",
-        disallow: "/",
-      },
-      {
-        userAgent: "anthropic-ai",
-        disallow: "/",
+        allow: "/",
       },
       {
         userAgent: "ClaudeBot",
-        disallow: "/",
+        allow: "/",
+      },
+      {
+        userAgent: "Claude-SearchBot",
+        allow: "/",
+      },
+      {
+        userAgent: "anthropic-ai",
+        allow: "/",
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+      },
+      {
+        userAgent: "Google-Extended",
+        allow: "/",
+      },
+      {
+        userAgent: "Applebot-Extended",
+        allow: "/",
+      },
+      {
+        userAgent: "CCBot",
+        allow: "/",
       },
       {
         userAgent: "cohere-ai",
-        disallow: "/",
+        allow: "/",
       },
+      // Blocked — TikTok scraper
       {
         userAgent: "Bytespider",
         disallow: "/",


### PR DESCRIPTION
## Summary
- **robots.ts**: 11개 AI 봇 명시적 Allow 전환 (GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot 등) — Bytespider만 차단 유지
- **JSON-LD Organization**: legalName 수정, sameAs/foundingDate/areaServed 추가, seller name 통일
- **speakable schema**: homepage, blog, faq에 SpeakableSpecification 추가
- **llms.txt + llms-full.txt**: AI 크롤러용 사이트 요약 파일 생성
- **alternates 보완**: faq, about 페이지에 ko locale 추가

## Test plan
- [x] `npm run build` 성공
- [x] `vitest run robots.test.ts` 6/6 통과
- [ ] staging 배포 후 `curl /robots.txt` AI 봇 Allow 확인
- [ ] staging 배포 후 `curl /llms.txt` 접근 확인
- [ ] JSON-LD 유효성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)