### PR TITLE
[ai-architect] AEO 최적화: 메타 설명 + ko locale + llms.txt 수정

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -7,40 +7,40 @@ AI Native Playbook Series bridges the gap between reading business books and exe
 
 ## Products (Detailed)
 
-### Vol.1: DotCom Secrets AI
+### Vol.1: AI Marketing Architect
 - Based on: Russell Brunson's DotCom Secrets
-- What it does: Automates sales funnel creation, value ladder design, and traffic strategy using AI
-- Includes: 20+ prompt templates for funnel building, lead magnet creation, and upsell sequences
+- What it does: Automates Value Ladder design, Hook-Story-Offer content, 7-Phase Funnel system, and Soap Opera email sequences using AI
+- Includes: AI Marketing Architect system prompt, prompt templates for each framework step, 4 case studies
 - Price: $17
 
-### Vol.2: Product Launch Formula AI
-- Based on: Jeff Walker's Product Launch Formula (PLF)
-- What it does: Automates product launch sequences, pre-launch content, and email campaigns using AI
-- Includes: Complete AI-powered launch sequence templates, sideways sales letter prompts
+### Vol.2: AI Brand Architect
+- Based on: Russell Brunson's Expert Secrets
+- What it does: Automates Mass Movement design, Epiphany Bridge storytelling, Belief System architecture, and Perfect Webinar scripts using AI
+- Includes: AI Brand Architect system prompt, Belief System Builder, Perfect Webinar Script Generator
 - Price: $17
 
-### Vol.3: Copywriting Secrets AI
+### Vol.3: AI Traffic Architect
+- Based on: Russell Brunson's Traffic Secrets
+- What it does: Automates Dream Customer avatar creation, Dream 100 list building, platform-specific content strategies, and Follow-Up Funnels using AI
+- Includes: AI Traffic Architect system prompt, Dream 100 Builder, Platform Strategy Generator
+- Price: $17
+
+### Vol.4: AI Story Architect
 - Based on: Jim Edwards' Copywriting Secrets
-- What it does: Automates headline writing, sales copy, and email sequences using AI
-- Includes: 30+ copywriting prompt templates for headlines, bullets, stories, and CTAs
+- What it does: Automates personal story mining, Hero's Journey structuring, headline generation, and platform-specific copywriting using AI
+- Includes: AI Story Architect system prompt, Personal Story Extractor, Headline Generator (3 formula categories)
 - Price: $17
 
-### Vol.4: The Art and Business of Online Writing AI
-- Based on: Nicolas Cole's online writing system
-- What it does: Automates content creation, headline optimization, and audience building using AI
-- Includes: AI writing system for consistent content production and audience growth
+### Vol.5: AI Startup Architect
+- Based on: Jeff Walker's Product Launch Formula (PLF)
+- What it does: Automates PLF 4-Phase launch structure, 9 Mental Triggers, Prelaunch Content sequences, and 7-Day Launch Email series using AI
+- Includes: AI Startup Architect system prompt, Prelaunch Content Generator, Launch Email Sequence Generator
 - Price: $17
 
-### Vol.5: AI Marketing Playbook
-- Comprehensive AI marketing automation system
-- What it does: Integrates marketing channels (SEO, email, social, ads) into AI-automated workflows
-- Includes: Marketing automation templates, analytics prompts, campaign optimization
-- Price: $17
-
-### Vol.6: AI Agent Skills
-- Build and deploy AI agents for business tasks
-- What it does: Teaches how to create specialized AI agents that handle business operations
-- Includes: Agent architecture patterns, tool use patterns, multi-agent coordination
+### Vol.6: AI Content Architect
+- Based on: Nicolas Cole's The Art and Business of Online Writing
+- What it does: Automates category design, Infinite Ideas Matrix (20 ideas from 1 topic), content atomization (1 article to 5 platforms), and monetization pipeline using AI
+- Includes: AI Content Architect system prompt, Infinite Ideas Matrix Generator, Content Atomizer (1 article to 5 platforms)
 - Price: $17
 
 ### Complete Bundle

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,12 +6,12 @@
 AI Native Playbook is a series of 6 digital guides (PDF) designed for entrepreneurs, marketers, and AI-native builders. Each guide transforms a world-class business framework into an AI-automated system with ready-to-use prompt templates.
 
 ## Products
-- Vol.1: DotCom Secrets AI — Russell Brunson's funnel framework automated with AI
-- Vol.2: Product Launch Formula AI — Jeff Walker's launch system automated with AI
-- Vol.3: Copywriting Secrets AI — Jim Edwards' copywriting framework automated with AI
-- Vol.4: The Art and Business of Online Writing AI — Nicolas Cole's writing system automated with AI
-- Vol.5: AI Marketing Playbook — Comprehensive AI marketing automation system
-- Vol.6: AI Agent Skills — Build and deploy AI agents for business tasks
+- Vol.1: AI Marketing Architect — Russell Brunson's DotCom Secrets funnel framework automated with AI
+- Vol.2: AI Brand Architect — Russell Brunson's Expert Secrets brand-building automated with AI
+- Vol.3: AI Traffic Architect — Russell Brunson's Traffic Secrets traffic strategy automated with AI
+- Vol.4: AI Story Architect — Jim Edwards' Copywriting Secrets framework automated with AI
+- Vol.5: AI Startup Architect — Jeff Walker's Product Launch Formula automated with AI
+- Vol.6: AI Content Architect — Nicolas Cole's online writing system automated with AI
 - Complete Bundle (6 books): $47
 
 ## Key Facts

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -9,7 +9,7 @@ import { getTranslations } from "next-intl/server";
 const aboutMeta: Record<string, { title: string; description: string }> = {
   en: {
     title: "About AI Native Playbook Series — Why We Built AI-Powered Business Framework Guides",
-    description: "Bridge the gap between reading and executing proven business frameworks. AI Native Playbook turns DotCom Secrets, PLF, and Copywriting Secrets into AI systems.",
+    description: "AI Native Playbook Series bridges the gap between reading and executing proven business frameworks. 6 AI-powered PDF guides that turn Russell Brunson, Jeff Walker, Jim Edwards systems into automated workflows.",
   },
   ko: {
     title: "AI Native Playbook Series 소개 — AI 기반 비즈니스 프레임워크 가이드를 만든 이유",

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -73,6 +73,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       canonical: canonicalUrl,
       languages: {
         en: `${siteUrl}/blog/${slug}`,
+        ko: `${siteUrl}/ko/blog/${slug}`,
         ja: `${siteUrl}/ja/blog/${slug}`,
         "x-default": canonicalUrl,
       },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata({
       canonical: pageUrl,
       languages: {
         en: SITE_URL,
+        ko: `${SITE_URL}/ko`,
         ja: `${SITE_URL}/ja`,
         "x-default": SITE_URL,
       },

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -86,6 +86,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       canonical: canonicalUrl,
       languages: {
         en: siteUrl,
+        ko: `${siteUrl}/ko`,
         ja: `${siteUrl}/ja`,
         "x-default": siteUrl,
       },

--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -48,6 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       canonical: canonicalUrl,
       languages: {
         en: `${siteUrl}/products/${slug}`,
+        ko: `${siteUrl}/ko/products/${slug}`,
         ja: `${siteUrl}/ja/products/${slug}`,
         "x-default": canonicalUrl,
       },


### PR DESCRIPTION
## Summary
- About page meta description optimized with brand name first for AI citation
- Added missing `ko` locale to hreflang alternates on home, layout, blog posts, and product pages
- Fixed llms.txt and llms-full.txt product names to match actual product titles (Vol.1-6)

Note: robots.ts AI crawler Allow, JSON-LD Organization branding, speakable schema, and llms.txt creation were already completed in previous commit af5b58e.

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Verify robots.txt shows AI crawler Allow rules
- [ ] Verify llms.txt accessible and product names correct
- [ ] Check hreflang ko locale present in page source

Generated with Claude Code