### PR TITLE
[ai-architect-global] staging → production: 블로그 예약발행 구현 배포

### DIFF
--- a/src/__tests__/blog-api.test.ts
+++ b/src/__tests__/blog-api.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const TEST_API_KEY = "test-key-for-unit-tests";
+
+const BLOG_DIR = path.join(process.cwd(), "content/blog");
+const TEST_SLUG = "test-scheduled-post-unit";
+const TEST_FILE = path.join(BLOG_DIR, `${TEST_SLUG}.md`);
+
+// next/cache mock: revalidatePath는 런타임(Vercel)에서만 동작하므로 테스트에서 mock
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("/api/blog/posts", () => {
+  beforeEach(() => {
+    // 각 테스트 전에 env 설정
+    vi.stubEnv("BLOG_API_KEY", TEST_API_KEY);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    // 테스트 파일 정리
+    if (fs.existsSync(TEST_FILE)) {
+      fs.unlinkSync(TEST_FILE);
+    }
+  });
+
+  it("인증 없이 요청 시 401", async () => {
+    const { POST } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug: TEST_SLUG, title: "Test", content: "body" }),
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(401);
+  });
+
+  it("slug 필수 필드 누락 시 400", async () => {
+    const { POST } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": TEST_API_KEY,
+      },
+      body: JSON.stringify({ title: "Test", content: "body" }),
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("유효한 scheduledAt으로 파일 생성", async () => {
+    const { POST } = await import("@/app/api/blog/posts/route");
+    const scheduledAt = "2026-12-25T00:00:00Z";
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": TEST_API_KEY,
+      },
+      body: JSON.stringify({
+        slug: TEST_SLUG,
+        title: "Test Scheduled Post",
+        content: "Test body content",
+        scheduledAt,
+      }),
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.slug).toBe(TEST_SLUG);
+    expect(body.created).toBe(true);
+    expect(body.published).toBe(false); // 미래 예약이므로 아직 미공개
+    expect(body.scheduledAt).toBe(scheduledAt);
+
+    // 파일 존재 + frontmatter 확인
+    expect(fs.existsSync(TEST_FILE)).toBe(true);
+    const raw = fs.readFileSync(TEST_FILE, "utf-8");
+    expect(raw).toContain(`scheduledAt: "${scheduledAt}"`);
+  });
+
+  it("잘못된 scheduledAt 형식 → 400", async () => {
+    const { POST } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": TEST_API_KEY,
+      },
+      body: JSON.stringify({
+        slug: TEST_SLUG,
+        title: "Test",
+        content: "body",
+        scheduledAt: "not-a-date",
+      }),
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("slug에 대문자 포함 시 400", async () => {
+    const { POST } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": TEST_API_KEY,
+      },
+      body: JSON.stringify({
+        slug: "Invalid-Slug-With-Capital",
+        title: "Test",
+        content: "body",
+      }),
+    });
+    const res = await POST(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it("GET 인증 없이 요청 시 401", async () => {
+    const { GET } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "GET",
+    });
+    const res = await GET(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET 인증 성공 시 posts 목록 반환", async () => {
+    const { GET } = await import("@/app/api/blog/posts/route");
+    const req = new Request("http://localhost/api/blog/posts", {
+      method: "GET",
+      headers: { "x-api-key": TEST_API_KEY },
+    });
+    const res = await GET(req as unknown as import("next/server").NextRequest);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.posts)).toBe(true);
+    expect(typeof body.total).toBe("number");
+  });
+});

--- a/src/__tests__/blog-scheduled-publish.test.ts
+++ b/src/__tests__/blog-scheduled-publish.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isPostVisible } from "@/lib/blog";
+
+describe("isPostVisible", () => {
+  const now = new Date("2026-03-19T12:00:00Z");
+
+  it("published 미설정 + scheduledAt 미설정 → true (기본 공개)", () => {
+    expect(isPostVisible({}, now)).toBe(true);
+  });
+
+  it("published: true + scheduledAt 미설정 → true", () => {
+    expect(isPostVisible({ published: true }, now)).toBe(true);
+  });
+
+  it("published: false → false (초안)", () => {
+    expect(isPostVisible({ published: false }, now)).toBe(false);
+  });
+
+  it("published: true + scheduledAt 미래 → false (예약 대기)", () => {
+    expect(
+      isPostVisible(
+        { published: true, scheduledAt: "2026-03-20T12:00:00Z" },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it("published: true + scheduledAt 과거 → true (공개)", () => {
+    expect(
+      isPostVisible(
+        { published: true, scheduledAt: "2026-03-18T12:00:00Z" },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("published: true + scheduledAt 현재와 동일 → true (경계값)", () => {
+    expect(
+      isPostVisible(
+        { published: true, scheduledAt: "2026-03-19T12:00:00Z" },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("scheduledAt 빈 문자열 → true (무시)", () => {
+    expect(isPostVisible({ scheduledAt: "" }, now)).toBe(true);
+  });
+
+  it("scheduledAt 유효하지 않은 문자열 → true (무시, 안전한 기본값)", () => {
+    expect(isPostVisible({ scheduledAt: "invalid-date" }, now)).toBe(true);
+  });
+
+  it("published: false + scheduledAt 과거 → false (published가 우선)", () => {
+    expect(
+      isPostVisible(
+        { published: false, scheduledAt: "2026-03-18T12:00:00Z" },
+        now
+      )
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/blog.test.ts
+++ b/src/__tests__/blog.test.ts
@@ -5,6 +5,7 @@ import {
   getPostsByCategory,
   getAllCategories,
   getAllTags,
+  isPostVisible,
 } from "@/lib/blog";
 
 describe("Blog", () => {
@@ -98,5 +99,36 @@ describe("Blog", () => {
   it("getPostsByCategory returns empty array for unknown category", () => {
     const filtered = getPostsByCategory("__nonexistent_category__");
     expect(filtered).toEqual([]);
+  });
+});
+
+describe("Blog scheduled publish integration", () => {
+  it("getAllPosts does not include posts with published: false", () => {
+    const posts = getAllPosts();
+    for (const post of posts) {
+      expect(isPostVisible(post)).toBe(true);
+    }
+  });
+
+  it("getAllPosts does not include future-scheduled posts", () => {
+    const posts = getAllPosts();
+    const now = new Date();
+    for (const post of posts) {
+      if (post.scheduledAt) {
+        expect(new Date(post.scheduledAt).getTime()).toBeLessThanOrEqual(
+          now.getTime()
+        );
+      }
+    }
+  });
+
+  it("getPostBySlug returns null for unpublished slug (simulated via isPostVisible)", () => {
+    // 현재 실제 published:false 파일이 없으므로 로직 자체 검증
+    // isPostVisible의 동작은 blog-scheduled-publish.test.ts에서 완전 검증됨
+    const posts = getAllPosts();
+    // getAllPosts 결과가 모두 isPostVisible=true 임을 확인
+    for (const post of posts) {
+      expect(isPostVisible(post)).toBe(true);
+    }
   });
 });

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getPostBySlug, getAllPosts, getRelatedPosts } from "@/lib/blog";
+import { getPostBySlug, getAllPosts, getRelatedPosts, getAllPostSlugs } from "@/lib/blog";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import ReactMarkdown from "react-markdown";
@@ -13,10 +13,12 @@ import { books } from "@/lib/products";
 import BlogInlineCTA from "@/components/BlogInlineCTA";
 import { splitContentAtMidpoint } from "@/lib/blog-content-utils";
 
+export const revalidate = 60; // 60초마다 재검증 — 예약 시각 도래 시 자동 공개
+
 export function generateStaticParams() {
-  const posts = getAllPosts();
+  const slugs = getAllPostSlugs();
   return routing.locales.flatMap((locale) =>
-    posts.map((p) => ({ locale, slug: p.slug }))
+    slugs.map((slug) => ({ locale, slug }))
   );
 }
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -6,6 +6,8 @@ import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import BlogFilterClient from "@/components/blog/BlogFilterClient";
 
+export const revalidate = 60; // 60초마다 재검증 — 예약 시각 도래 시 목록 자동 갱신
+
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com").trim();
 
 const blogMeta: Record<string, { title: string; description: string; ogDescription: string }> = {

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { revalidatePath } from "next/cache";
+
+const BLOG_DIR = path.join(process.cwd(), "content/blog");
+
+function checkAuth(req: NextRequest): boolean {
+  const apiKey = req.headers.get("x-api-key");
+  return apiKey === process.env.BLOG_API_KEY;
+}
+
+export async function POST(req: NextRequest) {
+  if (!checkAuth(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const {
+      slug,
+      title,
+      description,
+      date,
+      category,
+      tags,
+      locale,
+      content,
+      published,
+      scheduledAt,
+    } = body;
+
+    if (!slug || !title || !content) {
+      return NextResponse.json(
+        { error: "slug, title, content are required" },
+        { status: 400 }
+      );
+    }
+
+    // slug 검증: 영문 소문자, 숫자, 하이픈만 허용
+    if (!/^[a-z0-9-]+$/.test(slug)) {
+      return NextResponse.json(
+        { error: "slug must contain only lowercase letters, numbers, and hyphens" },
+        { status: 400 }
+      );
+    }
+
+    const filePath = path.join(BLOG_DIR, `${slug}.md`);
+
+    // 중복 slug 방지
+    if (fs.existsSync(filePath)) {
+      return NextResponse.json(
+        { error: `Post with slug '${slug}' already exists` },
+        { status: 409 }
+      );
+    }
+
+    // scheduledAt 유효성 검증
+    if (scheduledAt) {
+      const scheduledDate = new Date(scheduledAt);
+      if (isNaN(scheduledDate.getTime())) {
+        return NextResponse.json(
+          { error: "Invalid scheduledAt format. Use ISO 8601." },
+          { status: 400 }
+        );
+      }
+    }
+
+    // frontmatter 구성
+    const frontmatter: Record<string, unknown> = {
+      title,
+      description: description || "",
+      date: date || new Date().toISOString().split("T")[0],
+      category: category || "General",
+      tags: tags || [],
+    };
+    if (locale) frontmatter.locale = locale;
+    if (published === false) frontmatter.published = false;
+    if (scheduledAt) frontmatter.scheduledAt = scheduledAt;
+
+    // YAML frontmatter 생성
+    const yamlLines = Object.entries(frontmatter).map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return `${key}: [${(value as string[]).map((v) => `"${v}"`).join(", ")}]`;
+      }
+      if (typeof value === "boolean") return `${key}: ${value}`;
+      return `${key}: "${value}"`;
+    });
+
+    const fileContent = `---\n${yamlLines.join("\n")}\n---\n\n${content}\n`;
+
+    // 디렉토리 보장
+    if (!fs.existsSync(BLOG_DIR)) {
+      fs.mkdirSync(BLOG_DIR, { recursive: true });
+    }
+
+    fs.writeFileSync(filePath, fileContent, "utf-8");
+
+    // ISR 재검증 트리거
+    revalidatePath("/en/blog");
+    revalidatePath("/ko/blog");
+    revalidatePath("/ja/blog");
+
+    return NextResponse.json(
+      {
+        slug,
+        created: true,
+        published:
+          published !== false &&
+          (!scheduledAt || new Date(scheduledAt).getTime() <= Date.now()),
+        scheduledAt: scheduledAt || null,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[api/blog/posts] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: NextRequest) {
+  if (!checkAuth(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 내부용: 모든 포스트 (hidden 포함) 목록 반환
+  const files = fs.existsSync(BLOG_DIR)
+    ? fs.readdirSync(BLOG_DIR).filter((f) => f.endsWith(".md"))
+    : [];
+
+  const matter = (await import("gray-matter")).default;
+
+  const posts = files.map((file) => {
+    const raw = fs.readFileSync(path.join(BLOG_DIR, file), "utf-8");
+    const { data } = matter(raw);
+    return {
+      slug: file.replace(/\.md$/, ""),
+      title: data.title ?? "",
+      published: data.published !== false,
+      scheduledAt: data.scheduledAt || null,
+      date: data.date ?? "",
+      locale: data.locale ?? "en",
+    };
+  });
+
+  return NextResponse.json({ posts, total: posts.length });
+}

--- a/src/app/sitemap-blog.xml/route.ts
+++ b/src/app/sitemap-blog.xml/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getAllPosts, getAllCategories, getAllTags } from "@/lib/blog";
 
+export const revalidate = 3600; // 1시간 캐시 (sitemap은 빈번한 갱신 불필요)
+
 const BASE_URL =
   (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-driven-architect.com").trim();
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -16,6 +16,34 @@ export interface BlogPost {
   content: string;
   /** frontmatter locale 필드. 미설정 시 "en" 으로 간주 */
   locale?: string;
+  /** 명시적 비공개(false)일 때만 초안 처리. 미설정 = true 간주 */
+  published?: boolean;
+  /** ISO 8601 예약 발행 시각. 미래이면 비공개. 비어있거나 미설정이면 즉시 공개 */
+  scheduledAt?: string;
+}
+
+/**
+ * 포스트가 현재 시점에서 공개 가능한지 판별.
+ * - published가 명시적으로 false면 비공개
+ * - scheduledAt이 미래 시각이면 비공개
+ * - 그 외 공개
+ */
+export function isPostVisible(
+  post: { published?: boolean; scheduledAt?: string },
+  now: Date = new Date()
+): boolean {
+  // published가 명시적으로 false면 비공개
+  if (post.published === false) return false;
+
+  // scheduledAt이 있고 미래 시각이면 비공개
+  if (post.scheduledAt) {
+    const scheduledDate = new Date(post.scheduledAt);
+    if (!isNaN(scheduledDate.getTime()) && scheduledDate.getTime() > now.getTime()) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function getAllPosts(): Omit<BlogPost, "content">[] {
@@ -36,8 +64,11 @@ export function getAllPosts(): Omit<BlogPost, "content">[] {
         category: data.category ?? "General",
         readingTime: stats.text,
         locale: (data.locale as string | undefined) ?? "en",
+        published: data.published as boolean | undefined,
+        scheduledAt: data.scheduledAt as string | undefined,
       };
     })
+    .filter((post) => isPostVisible(post))
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
@@ -47,7 +78,8 @@ export function getPostBySlug(slug: string): BlogPost | null {
   const raw = fs.readFileSync(filePath, "utf-8");
   const { data, content } = matter(raw);
   const stats = readingTime(raw);
-  return {
+
+  const post = {
     slug,
     title: data.title ?? slug,
     description: data.description ?? "",
@@ -57,7 +89,14 @@ export function getPostBySlug(slug: string): BlogPost | null {
     readingTime: stats.text,
     content,
     locale: (data.locale as string | undefined) ?? "en",
+    published: data.published as boolean | undefined,
+    scheduledAt: data.scheduledAt as string | undefined,
   };
+
+  // 비공개 포스트 직접 접근 차단
+  if (!isPostVisible(post)) return null;
+
+  return post;
 }
 
 export function getPostsByCategory(category: string): Omit<BlogPost, "content">[] {
@@ -133,4 +172,16 @@ export function getRelatedPosts(
   const matchedSlugs = new Set(matched.map((p) => p.slug));
   const fallback = all.filter((p) => !matchedSlugs.has(p.slug)).slice(0, limit - matched.length);
   return [...matched, ...fallback].slice(0, limit);
+}
+
+/**
+ * 발행 상태와 무관하게 모든 포스트 slug 목록 반환.
+ * generateStaticParams() 전용 — 렌더링에 사용 금지.
+ */
+export function getAllPostSlugs(): string[] {
+  if (!fs.existsSync(BLOG_DIR)) return [];
+  return fs
+    .readdirSync(BLOG_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => f.replace(/\.md$/, ""));
 }


### PR DESCRIPTION
## Summary

- PR #200 머지 반영: 블로그 예약발행 구현 (isPostVisible + ISR + API)
- staging → production 승격

## Changes

- `isPostVisible()` 헬퍼: published=false/scheduledAt 미래 포스트 숨김 처리
- ISR revalidate=60: 예약 시각 도달 시 자동 공개
- `POST/GET /api/blog/posts` 엔드포인트 추가
- 210 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)