### PR TITLE
feat: publish 3 blog posts (AI-Native SaaS, Builder Story, Playbook)

### DIFF
--- a/content/blog/ai-native-product-builder-playbook.md
+++ b/content/blog/ai-native-product-builder-playbook.md
@@ -1,0 +1,60 @@
+---
+title: "The AI-Native Product Builder's Playbook: Ship Your First Product in 30 Days"
+description: "A step-by-step framework to go from idea to paying customers in 30 days — no team, no funding, just you and AI tools."
+date: "2026-03-22"
+author: "AI Native Playbook"
+category: "Builder Guide"
+tags: ["AI-native", "product building", "playbook", "30-day challenge", "solopreneur"]
+keywords: ["AI product builder playbook", "ship AI product 30 days", "AI-native product framework", "solo founder guide", "AI startup launch"]
+featured: false
+---
+
+# The AI-Native Product Builder's Playbook: Ship Your First Product in 30 Days
+
+**Most people spend months learning about AI without shipping anything. Here's the exact framework to go from idea to paying customers in 30 days — no team, no funding, just you and the right approach.**
+
+---
+
+## Why Most AI Products Never Launch
+
+There are thousands of people right now watching tutorials, bookmarking articles, and 'researching' AI tools. Six months from now, they'll still be researching. The problem isn't knowledge. It's the gap between understanding AI and actually building something people will pay for. The ones who succeed share one trait: they ship before they're ready.
+
+## Phase 1: Find the Pain (Days 1-3)
+
+Don't start with 'what AI can do.' Start with 'what takes too long.' The best AI-native products solve workflows that are: Repetitive (done 3x+ per week), Time-consuming (30+ min each), Error-prone (humans make mistakes), Data-heavy (processing text/images/numbers).
+
+How to find these: 1) Audit your own day 2) Browse Reddit/Twitter for 'I wish there was a tool that...' 3) Talk to 5 people and ask 'What's the most tedious part of your job?' If 3/5 describe the same pain, you have a product idea.
+
+## Phase 2: Prototype with AI APIs (Days 4-10)
+
+The minimum viable stack: Next.js + Tailwind (frontend), Claude/GPT API (AI), Supabase (DB), Vercel (hosting), Clerk (auth). Total cost: $0-20/month. Prototype rules: Solve exactly one workflow end-to-end. User gets value within 60 seconds. No settings pages. It should feel like magic.
+
+The AI integration pattern: User Input -> Pre-processing -> AI Call (with tested prompt) -> Post-processing -> Actionable Output. Don't make AI do everything. Use it where human judgment is slowest. Common mistake: Building an 'AI wrapper' that just relays API responses. Your value is in pre/post-processing.
+
+## Phase 3: Ship to 10 People (Days 11-17)
+
+Your prototype is ugly. Ship it anyway. Find users on Reddit (3 relevant subreddits), LinkedIn DMs (20 messages), Indie Hackers, Twitter/X. After each session, ask: 'Did it solve the problem?' 'What was confusing?' 'Would you use this again tomorrow?' Question 3 is the only one that matters. 7/10 yes = you have something.
+
+## Phase 4: Charge Money (Days 18-24)
+
+Free users give feedback. Paying users give truth. Start with flat monthly pricing at $9-19/month. 100 users at $9 = $900 MRR. Use Stripe or Lemon Squeezy. Send beta users: 'Paid plans launch next week. 50% off for life as a thank-you.' If 3+ convert, you have a business.
+
+## Phase 5: Iterate Weekly (Days 25-30+)
+
+AI-native superpower: ship improvements in hours. Weekly cycle: Monday (review data), Tue-Thu (build ONE improvement), Friday (ship + email users). Optimize in order: 1) Activation 2) Retention 3) Revenue 4) Expansion. Don't optimize revenue before activation.
+
+## What You Don't Need
+
+No co-founder needed. No VC funding. No perfect product (v1 should embarrass you slightly). No massive audience (10 paying users > 10,000 followers). No original idea (take existing workflow, make it 10x faster).
+
+## Common Pitfalls
+
+1) Building a 'platform' instead of a tool. 2) Over-engineering the AI (no fine-tuning in week one). 3) Ignoring the 'native' — let AI be the primary interaction. 4) Waiting for the 'right' model. 5) Solving only your own problem without validating with others.
+
+## Start Today
+
+The gap between 'I should build something' and 'I have paying customers' is exactly 30 days. Day 1 starts with one question: What painful, repetitive workflow can I make 10x faster with AI? Answer that, and you have everything you need to begin.
+
+---
+
+**Subscribe to the AI-Native Playbook newsletter at ai-native-playbook.com for weekly frameworks, case studies, and builder interviews. The best AI-native products weren't built by the smartest people. They were built by the ones who shipped first.**

--- a/content/blog/ai-native-vs-traditional-saas-2026.md
+++ b/content/blog/ai-native-vs-traditional-saas-2026.md
@@ -1,0 +1,60 @@
+---
+title: "AI-Native vs Traditional SaaS: A Data-Driven Comparison for 2026"
+description: "A comprehensive data-driven analysis comparing AI-native and traditional SaaS across development speed, team structure, pricing, and growth patterns in 2026."
+date: "2026-03-21"
+author: "AI Native Playbook"
+category: "Industry Analysis"
+tags: ["AI-native", "SaaS", "data analysis", "startup", "comparison"]
+keywords: ["AI-native vs traditional SaaS", "SaaS comparison 2026", "AI-native startup data", "SaaS development speed", "AI SaaS efficiency"]
+featured: false
+---
+
+# AI-Native vs Traditional SaaS: A Data-Driven Comparison for 2026
+
+**The SaaS industry generated $197 billion in 2023. By 2028, the companies that survive will look fundamentally different. Here's what the data tells us about the shift.**
+
+---
+
+## Defining the Terms
+
+Traditional SaaS: Software built around human-designed workflows. Users navigate menus, fill forms, click buttons. AI might be added as a feature, but the core interaction is unchanged (Salesforce, HubSpot, Monday.com). AI-Native SaaS: Software where AI is the primary interaction layer. The user describes what they want; the system figures out how (Cursor, Perplexity, Harvey AI). The difference is architectural.
+
+## 1. Development Speed
+
+Traditional: 3-6 months to MVP, 3-5 devs, $150K-500K cost. AI-Native: 2-6 weeks to MVP, 1-2 devs, $0-5K cost. YC W2026: 66% of AI-native startups built by solo/duo founders. Median launch time: 23 days (vs 4.5 months in W2020). The barrier to entry has collapsed.
+
+## 2. Team Structure
+
+Companies reaching $1M ARR — AI-native median team: 4.2 people, Traditional median: 14 people. Revenue per employee: AI-native $238K vs Traditional $71K. A 3.4x efficiency gap that's widening.
+
+## 3. User Experience
+
+AI-native products show 47% higher activation rates, 62% lower support tickets, 31% higher DAU ratios. But 23% higher first-month churn — users who don't see immediate magic leave faster. The bar for first impressions is higher.
+
+## 4. Pricing Models
+
+41% of AI-native companies use usage/outcome-based pricing. Results: 24% higher NRR (118% vs 95%), 37% higher expansion revenue at month 12. AI usage naturally correlates with value received. Per-seat pricing penalizes efficiency.
+
+## 5. Competitive Moats
+
+Of 200 AI-native startups analyzed: 73% that failed cited 'no differentiation from raw API.' 82% that succeeded had deep vertical domain expertise. Only 11% had a meaningful technical moat. The moat isn't the model — it's the workflow.
+
+## 6. Development Costs
+
+Pre-revenue monthly burn: Traditional $87K vs AI-native $4.2K. A 20x cost difference. A solo founder with $50K savings has 12 months of runway — enough to test 3-4 product ideas.
+
+## 7. Growth Patterns
+
+AI-native to $100K ARR: median 4.7 months. Primary growth: product-led (67%). Median CAC: $47 (vs $271 traditional). But faster competitive response: median 3.2 months before a direct competitor appeared (vs 8.7 months traditional).
+
+## The Hybrid Reality
+
+AI-native wins on speed (10-20x), capital efficiency (3-4x), activation, and CAC. Traditional wins on retention (after month 3), moats, predictability, and compliance. The most successful 2026 companies are AI-native in UX but traditional in moat-building.
+
+## What This Means for Builders
+
+Starting new: Build AI-native from day one. Plan for moats early. Running traditional SaaS: Rebuild your core interaction around AI, or a faster competitor will. Investing: Watch for AI-native companies with retention past month 3 — that's where real value is.
+
+---
+
+**Subscribe to the AI-Native Playbook at ai-native-playbook.com for deep-dive analyses, builder interviews, and actionable frameworks every week. The model is the commodity. The workflow is the moat.**

--- a/content/blog/from-burned-out-pm-to-12k-ai-native.md
+++ b/content/blog/from-burned-out-pm-to-12k-ai-native.md
@@ -1,0 +1,64 @@
+---
+title: "From Burned-Out PM to $12K/mo: One Builder's AI-Native Journey"
+description: "How a non-technical product manager built an AI-native SaaS earning $12K/month in 8 months — with no coding background, no funding, and no team."
+date: "2026-03-22"
+author: "AI Native Playbook"
+category: "Case Study"
+tags: ["AI-native", "builder story", "solopreneur", "SaaS", "case study"]
+keywords: ["AI-native builder story", "non-technical founder", "solopreneur SaaS", "AI product revenue", "PM to founder"]
+featured: false
+---
+
+# From Burned-Out PM to $12K/mo: One Builder's AI-Native Journey
+
+**She couldn't code. She had no audience. She had $3,000 in savings and a LinkedIn profile that said 'Product Manager.' Eight months later, she runs an AI-native business that generates $12,000 per month.**
+
+---
+
+## The Breaking Point
+
+Sarah Chen was a PM at a mid-size SaaS company in Austin. $95K salary, decent benefits. But she spent 60% of time in meetings, 30% writing docs nobody read, 10% actually thinking about product. One Thursday she realized she'd been in seven back-to-back meetings without doing a single thing that mattered. By February 2026, she'd quit. By June, she was earning more than her PM salary.
+
+## The Observation
+
+Every week, Sarah wrote stakeholder updates. Same structure: what shipped, what learned, what's next. Three hours pulling data from Jira/Linear/Slack, then writing. Every single week. She tried Zapier (clunky), ChatGPT (no tool access). Then it hit her: if she was struggling with this as a PM at a tech company, thousands of other PMs were too. She'd found the pain.
+
+## The First Version
+
+Sarah couldn't code. Not a line of JavaScript. She wrote a one-page PRD, fed it to Claude for architecture guidance, then built with Cursor describing features in plain English. The first version crashed every third time. She shipped it anyway — November 15, 2025, three weeks after her revelation.
+
+## Finding the First Users
+
+She messaged 30 PMs she knew. Simple pitch: 'I built a tool that writes your stakeholder updates automatically. It's ugly and buggy. Want to try it for free?' 22 responded. 18 signed up. 14 used it. The feedback was brutal and beautiful. 'Saves me three hours but reads like a robot.' 'If you add Slack summaries, I'd pay $50/month.' She listened and iterated every weekend.
+
+## The Moment It Clicked
+
+Week four. A PM she'd never met DMed on LinkedIn: 'Someone in my PM community shared your tool. Can I get access?' No marketing. No public posts. Word of mouth was already working. She added Stripe that weekend. $19/mo individual, $49/mo teams. 9 of 14 beta users converted. Day one revenue: $171/month.
+
+## The Growth
+
+No hires. No funding. No ads. Week 6: Jira integration, $380/mo. Week 8: First LinkedIn post went modestly viral (2,400 likes), $890/mo. Week 12: Team features + Slack bot, $2,100/mo. Week 16: Featured in Lenny's Newsletter, $4,800/mo. Week 24: $8,500/mo, quit PM job. Month 8: $12,000/mo, 640 paying users, still solo.
+
+## 5 Decisions That Mattered
+
+1. Solved her own pain first (always knew if product was good enough). 2. Shipped embarrassingly early (crashes taught her, not shipping wouldn't have). 3. Charged from week four (paying users give truth, not just opinions). 4. Stayed solo longer than expected (forced ruthless prioritization). 5. Let distribution find her (one LinkedIn post drove more users than anything else).
+
+## What She'd Do Differently
+
+Team pricing from day one (teams convert at 12% vs 5% individual). Talk to enterprise buyers sooner ($500/mo team license vs $19/mo individual). Quit day job sooner (product grew faster full-time due to mental energy, not just hours).
+
+## The Bigger Picture
+
+Sarah has connected with dozens of similar builders: a recruiter ($7K/mo, month 6), a real estate agent ($4K/mo, month 4), a teacher ($9K/mo, month 7). None were engineers. All were domain experts. 'The pattern is always the same: someone who knows a workflow intimately uses AI to automate the most tedious part. The technology is the easy part.'
+
+## The Reality Check
+
+'This isn't get-rich-quick. I worked weekends for four months. My first month was $171. But it's proof that a non-technical person with domain expertise can build a real software business in 2026. That wasn't possible two years ago. It is now. But you have to actually ship. Most people never put something in front of users and say, Does this help you? That's the only question that matters.'
+
+## Where She Is Now
+
+March 2026 — UpdatePilot: 640 paying users, $12K MRR, 4.8% monthly churn, zero employees, plans for $25K MRR by year end. 'I make more than my PM salary. I work 30 hours instead of 50. I choose what I work on every day. That's the real win.'
+
+---
+
+**Subscribe to the AI-Native Playbook at ai-native-playbook.com for weekly frameworks, case studies, and builder interviews. You don't need permission to build. You just need to ship.**


### PR DESCRIPTION
## Summary
- 3 blog posts added to `content/blog/`:
  - `ai-native-vs-traditional-saas-2026.md` (2026-03-21)
  - `from-burned-out-pm-to-12k-ai-native.md` (2026-03-22)
  - `ai-native-product-builder-playbook.md` (2026-03-22)
- Content sourced from Notion content board (VP urgent directive)

## Test plan
- [ ] Verify blog posts render correctly on staging
- [ ] Merge staging -> production after verification