### PR TITLE
fix: add scheduledAt to 3 blog posts — hide until scheduled date

### DIFF
--- a/content/blog/ai-native-product-builder-playbook.md
+++ b/content/blog/ai-native-product-builder-playbook.md
@@ -7,6 +7,7 @@ category: "Builder Guide"
 tags: ["AI-native", "product building", "playbook", "30-day challenge", "solopreneur"]
 keywords: ["AI product builder playbook", "ship AI product 30 days", "AI-native product framework", "solo founder guide", "AI startup launch"]
 featured: false
+scheduledAt: "2026-03-22T14:00:00+09:00"
 ---
 
 # The AI-Native Product Builder's Playbook: Ship Your First Product in 30 Days

--- a/content/blog/ai-native-vs-traditional-saas-2026.md
+++ b/content/blog/ai-native-vs-traditional-saas-2026.md
@@ -7,6 +7,7 @@ category: "Industry Analysis"
 tags: ["AI-native", "SaaS", "data analysis", "startup", "comparison"]
 keywords: ["AI-native vs traditional SaaS", "SaaS comparison 2026", "AI-native startup data", "SaaS development speed", "AI SaaS efficiency"]
 featured: false
+scheduledAt: "2026-03-21T09:00:00+09:00"
 ---
 
 # AI-Native vs Traditional SaaS: A Data-Driven Comparison for 2026

--- a/content/blog/from-burned-out-pm-to-12k-ai-native.md
+++ b/content/blog/from-burned-out-pm-to-12k-ai-native.md
@@ -7,6 +7,7 @@ category: "Case Study"
 tags: ["AI-native", "builder story", "solopreneur", "SaaS", "case study"]
 keywords: ["AI-native builder story", "non-technical founder", "solopreneur SaaS", "AI product revenue", "PM to founder"]
 featured: false
+scheduledAt: "2026-03-22T09:00:00+09:00"
 ---
 
 # From Burned-Out PM to $12K/mo: One Builder's AI-Native Journey


### PR DESCRIPTION
## Summary
- 3 blog posts were published immediately instead of being scheduled
- Added `scheduledAt` frontmatter so `isPostVisible()` hides them until the scheduled date
- CEO flagged this issue

## Posts fixed
1. ai-native-vs-traditional-saas-2026 → 2026-03-21 09:00 KST
2. from-burned-out-pm-to-12k-ai-native → 2026-03-22 09:00 KST  
3. ai-native-product-builder-playbook → 2026-03-22 14:00 KST