### PR TITLE
fix: hide future-dated blog posts

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -26,10 +26,11 @@ export interface BlogPost {
  * 포스트가 현재 시점에서 공개 가능한지 판별.
  * - published가 명시적으로 false면 비공개
  * - scheduledAt이 미래 시각이면 비공개
+ * - date가 미래이면 비공개 (예약발행)
  * - 그 외 공개
  */
 export function isPostVisible(
-  post: { published?: boolean; scheduledAt?: string },
+  post: { published?: boolean; scheduledAt?: string; date?: string },
   now: Date = new Date()
 ): boolean {
   // published가 명시적으로 false면 비공개
@@ -39,6 +40,14 @@ export function isPostVisible(
   if (post.scheduledAt) {
     const scheduledDate = new Date(post.scheduledAt);
     if (!isNaN(scheduledDate.getTime()) && scheduledDate.getTime() > now.getTime()) {
+      return false;
+    }
+  }
+
+  // date가 미래이면 비공개 (예약발행 — date 도래 시 ISR revalidate로 자동 노출)
+  if (post.date) {
+    const postDate = new Date(post.date);
+    if (!isNaN(postDate.getTime()) && postDate.getTime() > now.getTime()) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Added `date` field check to `isPostVisible()` in `blog.ts`
- Posts with future dates are now hidden until their date arrives
- ISR revalidate (60s) ensures automatic visibility when date is reached

## Context
CEO urgent: 3/21 and 3/22 scheduled posts were appearing on 3/20.
Staged via PR #206.