### PR TITLE
feat: remove Coming Soon, connect Paddle checkout

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { books, bundle, getBundleUrl } from "@/lib/products";
+import { books, bundle, getBundleUrl, getBundlePaddlePriceId } from "@/lib/products";
 import { getAllPosts } from "@/lib/blog";
 import dynamic from "next/dynamic";
 const BuyButton = dynamic(() => import("@/components/BuyButton"), {
@@ -99,6 +99,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
   setRequestLocale(locale);
 
   const bundleUrl = getBundleUrl();
+  const bundlePaddlePriceId = getBundlePaddlePriceId();
   const latestPosts = getAllPosts().slice(0, 3);
 
   const t = await getTranslations("home");
@@ -282,7 +283,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-6">
-            <BuyButton href={bundleUrl} className="text-lg px-10 py-4">
+            <BuyButton href={bundleUrl} paddlePriceId={bundlePaddlePriceId} paddleSuccessUrl={`${siteUrl}/thank-you?product=Complete+Bundle`} className="text-lg px-10 py-4">
               {th("cta")} &mdash; ${bundle.price}
             </BuyButton>
             <Link
@@ -727,7 +728,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
                   {tc("moneyBack")}
                 </li>
               </ul>
-              <BuyButton href={bundleUrl} className="w-full text-lg py-4">
+              <BuyButton href={bundleUrl} paddlePriceId={bundlePaddlePriceId} paddleSuccessUrl={`${siteUrl}/thank-you?product=Complete+Bundle`} className="w-full text-lg py-4">
                 {th("cta")} &mdash; ${bundle.price}
               </BuyButton>
               <p className="text-xs text-text-muted mt-3">
@@ -790,11 +791,12 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       <StickyMobileCTA
         bundlePrice={bundle.price}
         bundleUrl={bundleUrl}
+        paddlePriceId={bundlePaddlePriceId}
+        paddleSuccessUrl={`${siteUrl}/thank-you?product=Complete+Bundle`}
         labels={{
           completeBundle: t("completeBundle"),
           instantDownload: tc("instantDownload"),
           moneyBack: tc("moneyBack"),
-          comingSoon: tc("comingSoon"),
           getBundle: tc("getBundle"),
         }}
       />

--- a/src/components/StickyMobileCTA.tsx
+++ b/src/components/StickyMobileCTA.tsx
@@ -5,19 +5,23 @@ import { useState, useEffect } from "react";
 export default function StickyMobileCTA({
   bundlePrice,
   bundleUrl,
+  paddlePriceId,
+  paddleSuccessUrl,
   labels,
 }: {
   bundlePrice: number;
   bundleUrl: string;
+  paddlePriceId?: string;
+  paddleSuccessUrl?: string;
   labels: {
     completeBundle: string;
     instantDownload: string;
     moneyBack: string;
-    comingSoon: string;
     getBundle: string;
   };
 }) {
   const [visible, setVisible] = useState(false);
+  const [paddleReady, setPaddleReady] = useState(false);
 
   useEffect(() => {
     function handleScroll() {
@@ -27,9 +31,45 @@ export default function StickyMobileCTA({
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  useEffect(() => {
+    if (!paddlePriceId) return;
+    function checkPaddle() {
+      if (window.Paddle?.Checkout) {
+        setPaddleReady(true);
+        return true;
+      }
+      return false;
+    }
+    if (checkPaddle()) return;
+    const interval = setInterval(() => {
+      if (checkPaddle()) clearInterval(interval);
+    }, 300);
+    const timeout = setTimeout(() => clearInterval(interval), 4000);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timeout);
+    };
+  }, [paddlePriceId]);
+
   if (!visible) return null;
 
-  const isDisabled = bundleUrl === "#" || !bundleUrl;
+  function handleBuyClick(e: React.MouseEvent) {
+    window.gtag?.("event", "cta_click", { event_category: "engagement", event_label: "sticky_mobile_cta", cta_location: "sticky_bottom" });
+    window.fbq?.("track", "InitiateCheckout", { content_name: "Complete Bundle (Sticky CTA)" });
+
+    if (paddlePriceId && paddleReady && window.Paddle?.Checkout) {
+      e.preventDefault();
+      window.Paddle.Checkout.open({
+        items: [{ priceId: paddlePriceId, quantity: 1 }],
+        settings: {
+          successUrl: paddleSuccessUrl,
+        },
+      });
+    }
+  }
+
+  // Use Paddle overlay if ready, otherwise fall back to href link
+  const usePaddleOverlay = !!paddlePriceId && paddleReady;
 
   return (
     <div
@@ -45,15 +85,20 @@ export default function StickyMobileCTA({
         </div>
         <div className="text-xs text-text-muted">{labels.instantDownload} · {labels.moneyBack}</div>
       </div>
-      {isDisabled ? (
-        <span className="bg-gold/20 text-gold px-4 py-2.5 rounded-lg text-xs font-bold">
-          {labels.comingSoon}
-        </span>
+      {usePaddleOverlay ? (
+        <button
+          type="button"
+          onClick={handleBuyClick}
+          className="bg-gold text-navy-dark px-5 py-2.5 rounded-lg text-sm font-bold hover:bg-gold-light transition-colors whitespace-nowrap cursor-pointer"
+        >
+          {labels.getBundle} &mdash; ${bundlePrice}
+        </button>
       ) : (
         <a
           href={bundleUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={handleBuyClick}
           aria-label={`${labels.getBundle} — $${bundlePrice} (opens in new tab)`}
           className="bg-gold text-navy-dark px-5 py-2.5 rounded-lg text-sm font-bold hover:bg-gold-light transition-colors whitespace-nowrap"
         >

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -38,8 +38,7 @@
     "lifetimeAccess": "Lifetime access",
     "pdfDownload": "Immediate PDF download",
     "worksWithAI": "Works with Claude, ChatGPT, Gemini",
-    "fullDetails": "See what's inside →",
-    "comingSoon": "Coming Soon"
+    "fullDetails": "See what's inside →"
   },
   "footer": {
     "tagline": "Six world-class business frameworks. Fully automated with AI. One price.",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -38,8 +38,7 @@
     "lifetimeAccess": "永久アクセス",
     "pdfDownload": "即時PDFダウンロード",
     "worksWithAI": "Claude、ChatGPT、Gemini対応",
-    "fullDetails": "詳細を見る",
-    "comingSoon": "近日公開"
+    "fullDetails": "詳細を見る"
   },
   "footer": {
     "tagline": "6つの世界クラスのビジネスフレームワーク。AIで完全自動化。一つの価格。",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -38,8 +38,7 @@
     "lifetimeAccess": "평생 이용",
     "pdfDownload": "즉시 PDF 다운로드",
     "worksWithAI": "Claude, ChatGPT, Gemini 호환",
-    "fullDetails": "상세 보기",
-    "comingSoon": "출시 예정"
+    "fullDetails": "상세 보기"
   },
   "footer": {
     "tagline": "6가지 세계적 비즈니스 프레임워크. AI로 완전 자동화. 하나의 가격.",


### PR DESCRIPTION
## Summary
- **StickyMobileCTA**: Removed the Coming Soon disabled badge. Now always shows a Buy button with Paddle overlay checkout support (falls back to href link if Paddle.js not loaded).
- **Homepage BuyButton**: Added `paddlePriceId` and `paddleSuccessUrl` props to both hero and pricing section BuyButton instances so Paddle checkout works directly from the homepage.
- **i18n cleanup**: Removed unused `comingSoon` keys from en.json, ko.json, ja.json.

## Test plan
- [ ] Verify StickyMobileCTA shows "Get All 6 Frameworks" button (not "Coming Soon") on mobile scroll
- [ ] Verify clicking Buy buttons on homepage opens Paddle checkout overlay
- [ ] Verify Paddle checkout works on bundle page, pricing page, and product pages (unchanged)
- [ ] Verify all three locales (en, ko, ja) render without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundle purchasing capability now enabled with integrated checkout.

* **Improvements**
  * Removed "Coming Soon" status from bundle offer.
  * Added post-purchase confirmation and tracking page.
  * Updated interface text across English, Japanese, and Korean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->