### PR TITLE
Add 2 blog posts: AI-native business & one-person AI setup

### DIFF
--- a/content/blog/how-to-start-ai-native-business-2026.md
+++ b/content/blog/how-to-start-ai-native-business-2026.md
@@ -1,0 +1,350 @@
+---
+title: "How to Start an AI-Native Business in 2026 — Complete Guide"
+description: "A practical, step-by-step guide to launching an AI-native business in 2026. Includes a 7-day launch plan, tool recommendations, revenue models, and FAQ."
+date: "2026-03-24"
+author: "AI Native Playbook"
+tags: ["ai-native", "startup", "business", "solopreneur"]
+category: "Business Strategy"
+readingTime: "13 min read"
+---
+
+The phrase "AI-powered business" has been thrown around since 2023. Most of the time, it means a traditional business that bolted a chatbot onto its website. That is not what we are talking about here.
+
+An AI-native business is one where AI is the operational backbone from day one — not an add-on, not an experiment, not a single tool in the stack. It means your content production, customer acquisition, sales process, and fulfillment all run through AI workflows that operate with minimal human intervention.
+
+This guide walks you through exactly how to build one in 2026, including the specific tools, the economics, and a 7-day launch plan you can execute this week.
+
+## What "AI-Native" Actually Means (And Why It Matters)
+
+An AI-native business differs from a traditional business in three structural ways:
+
+**1. The cost structure is inverted.** A traditional service business spends 60-80% of revenue on labor. An AI-native business spends 60-80% on tools and infrastructure — which scale without headcount. Your biggest expense is API tokens and SaaS subscriptions, not salaries.
+
+**2. Operations are asynchronous by default.** Instead of you doing each task sequentially, AI agents handle content creation, email sequences, lead scoring, and customer support simultaneously. You design the system once and intervene only for exceptions.
+
+**3. The moat is the system, not the individual.** In a traditional solopreneur business, if you stop working, revenue stops. In an AI-native business, the system continues operating. Your competitive advantage is the quality of your automation, not your personal availability.
+
+This distinction matters because it determines what you build, how you price it, and how fast you can scale. If you build a "business with AI tools," you have a slightly more efficient freelance practice. If you build an AI-native business, you have an asset that compounds.
+
+## The Economics: Why 2026 Is the Right Time
+
+Three things converged in 2025-2026 that make AI-native businesses genuinely viable for the first time:
+
+**Tool costs dropped below the viability threshold.** Running a full AI content pipeline (LLM API + image generation + scheduling) costs $50-150/month in 2026. Two years ago, the same output quality required $500-800/month in API costs alone.
+
+**Buyer sophistication increased.** Your customers now understand and accept AI-generated content, AI customer support, and AI-driven recommendations. The stigma is gone. What matters is quality, not the production method.
+
+**Integration infrastructure matured.** Tools like Make, n8n, and Zapier now offer native AI nodes. You can connect an LLM to your CRM, email platform, payment processor, and analytics dashboard without writing code. The plumbing that used to require a developer is now drag-and-drop.
+
+The combined result: you can launch a business that would have required a team of five in 2023 — with zero employees and under $200/month in operating costs.
+
+## Choosing Your AI-Native Business Model
+
+Not every business model works in an AI-native context. The best ones share three characteristics:
+
+1. **Digital delivery** — Physical products add logistics complexity that AI cannot handle
+2. **Repeatable processes** — AI excels at doing the same type of task thousands of times with slight variation
+3. **Knowledge or content as the core product** — This is where AI provides the highest leverage
+
+Here are the four models that work best in 2026:
+
+### Model 1: Automated Content Business
+
+You build a content engine that produces SEO-optimized articles, newsletters, or social media content at scale. Revenue comes from affiliate marketing, ad revenue, sponsored content, or premium subscriptions.
+
+**Why it works AI-native:** Content production is the task AI handles best. A well-designed pipeline can produce 50-100 high-quality articles per month with 2-3 hours of human oversight per week.
+
+**Revenue potential:** $2,000-$15,000/month depending on niche and monetization model.
+
+### Model 2: Productized AI Service
+
+You package a specific AI workflow as a done-for-you service. Examples: AI-powered email sequence creation, AI product photography, AI competitive analysis reports.
+
+**Why it works AI-native:** The client pays for the output, not your time. AI does 80% of the production work, so your margins are 70-85% instead of the 30-40% typical of traditional services.
+
+**Revenue potential:** $3,000-$20,000/month with 5-15 recurring clients.
+
+### Model 3: Digital Product + AI Funnel
+
+You create a digital product (course, template pack, ebook, software tool) and sell it through an AI-automated [sales funnel](/en/blog/ai-sales-funnel-guide-2026). AI handles lead generation, email nurturing, and even customer onboarding.
+
+**Why it works AI-native:** Once the product exists, the entire sales process runs on autopilot. AI writes the email sequences, segments the audience, and optimizes conversion based on data.
+
+**Revenue potential:** $1,000-$50,000/month depending on product price point and traffic.
+
+### Model 4: AI-Enhanced Consulting
+
+You offer strategic consulting in a specific domain, using AI to deliver analysis, reports, and recommendations at a speed and depth that justifies premium pricing.
+
+**Why it works AI-native:** AI turns you from a consultant who delivers one report per week into one who delivers daily insights. The value perception — and your pricing power — increases dramatically.
+
+**Revenue potential:** $5,000-$30,000/month with 3-8 clients.
+
+For a deeper comparison of AI business models, see our guide on [AI side hustles that actually generate income](/en/blog/ai-side-hustle-ideas-2026).
+
+## The AI-Native Tech Stack for 2026
+
+Every AI-native business needs five layers. Here is what each layer does and the best tool options in 2026:
+
+### Layer 1: AI Engine (Content + Analysis)
+
+This is your core production engine — the AI that generates content, analyzes data, and automates decision-making.
+
+- **Claude / GPT-4o** — Primary LLM for content and analysis
+- **Midjourney / DALL-E 3** — Visual content generation
+- **ElevenLabs** — Audio/voice content if needed
+
+**Monthly cost:** $20-100
+
+### Layer 2: Automation Platform
+
+This connects your AI engine to everything else. It is the central nervous system of your business.
+
+- **Make (Integromat)** — Best balance of power and ease of use
+- **n8n** — Self-hosted option for more control
+- **Zapier** — Simplest option, higher cost at scale
+
+**Monthly cost:** $20-70
+
+### Layer 3: Customer Acquisition
+
+How leads find you and enter your system.
+
+- **Content/SEO** — Blog, YouTube, social media (AI-produced)
+- **Brevo / ConvertKit** — Email marketing and automation
+- **Landing pages** — Your website or dedicated landing page builder
+
+**Monthly cost:** $0-50
+
+### Layer 4: Sales and Payments
+
+How you convert leads to customers and collect money.
+
+- **Paddle / Stripe** — Payment processing
+- **Your website** — Product pages and checkout
+- **AI email sequences** — Automated nurture and conversion
+
+**Monthly cost:** $0-30 (plus transaction fees)
+
+### Layer 5: Operations and Analytics
+
+How you monitor performance and optimize the system.
+
+- **Notion** — Business dashboard and knowledge base
+- **Google Analytics 4** — Traffic and conversion tracking
+- **PostHog / Mixpanel** — Product analytics if you have a software product
+
+**Monthly cost:** $0-30
+
+**Total stack cost: $60-280/month** — This runs a business that would cost $8,000-15,000/month in employee salaries.
+
+For a detailed breakdown of every tool in the solopreneur AI stack, read our [complete solopreneur AI stack guide](/en/blog/solopreneur-ai-stack).
+
+## The 7-Day Launch Plan
+
+Stop planning. Start building. Here is exactly what to do each day for the next seven days to launch your AI-native business.
+
+### Day 1: Choose Your Model and Niche
+
+- Pick one of the four models above
+- Choose a niche where you have either expertise or strong interest
+- Validate demand: search for existing products/services in your niche on Google, Product Hunt, and social media
+- Write a one-paragraph description of your offer
+
+**Deliverable:** A clear statement: "I will sell [product/service] to [audience] using [AI-native model]."
+
+### Day 2: Set Up Your AI Engine
+
+- Create accounts for your primary LLM (Claude or ChatGPT)
+- Build your first AI prompt template for your core deliverable
+- Test the output quality — generate three samples and evaluate honestly
+- Refine your prompts until the output requires less than 20% manual editing
+
+**Deliverable:** A working prompt system that produces your core deliverable at acceptable quality.
+
+### Day 3: Build Your Landing Page
+
+- Set up your website or landing page (even a simple one-page site works)
+- Write your value proposition (use AI to draft, then edit for authenticity)
+- Add a clear call-to-action: either buy now or join the email list
+- Set up your payment processor (Paddle or Stripe)
+
+**Deliverable:** A live URL where someone can learn about your offer and take action.
+
+### Day 4: Create Your Lead Magnet and Email Sequence
+
+- Build a free resource that demonstrates your expertise (checklist, template, mini-guide)
+- Set up your email platform (Brevo free tier works fine to start)
+- Write a 5-email welcome sequence using AI
+- Connect the lead magnet download to the email sequence
+
+**Deliverable:** A working lead capture system. Download our [free guide](/en/free-guide) to see an example of an effective lead magnet in action.
+
+### Day 5: Build Your Content Pipeline
+
+- Set up your automation platform (Make or Zapier)
+- Create your first content workflow: AI generates draft, you review, system publishes
+- Produce your first three pieces of content (blog posts, social media, or newsletter)
+- Schedule content for the next two weeks
+
+**Deliverable:** An automated content pipeline that runs with minimal daily input.
+
+### Day 6: Connect the Automation
+
+- Link your content pipeline to your landing page (internal links, CTAs)
+- Connect your email platform to your payment processor
+- Set up basic analytics (GA4 on your website)
+- Test the entire flow: content attracts visitor, visitor downloads lead magnet, email sequence nurtures, payment link converts
+
+**Deliverable:** A connected system where each component feeds the next.
+
+### Day 7: Launch and Distribute
+
+- Publish all prepared content
+- Share your launch on three platforms where your target audience spends time
+- Send a personal message to 10 people who might be interested (or who know people who might be)
+- Set up a daily 15-minute review routine: check analytics, review AI output quality, handle any manual tasks
+
+**Deliverable:** A live, operating AI-native business.
+
+This is not a theoretical exercise. Each day requires 3-5 hours of focused work. By the end of day seven, you have a functioning business with automated content production, lead capture, email nurture, and a payment mechanism. It will not generate $10,000 in month one. But the system is running, and every improvement you make from this point compounds.
+
+## Scaling From Launch to $10K/Month
+
+Getting to $10,000/month in an AI-native business follows a predictable path. Here is the progression:
+
+### Month 1-2: Foundation ($0-500/month)
+
+Focus on three things only:
+1. Produce content consistently (minimum 3x/week)
+2. Collect email subscribers (target: 200-500)
+3. Make your first sale — even at a discount — to validate the offer
+
+Do not optimize. Do not add features. Do not build complex automations. Get the basic loop working: content attracts traffic, traffic becomes leads, leads become customers.
+
+### Month 3-4: Optimization ($500-2,000/month)
+
+Now you have data. Use it:
+1. Which content drives the most traffic? Produce more like it
+2. Which emails get the highest open and click rates? Replicate the pattern
+3. Where do leads drop off in your funnel? Fix that step
+
+This is where AI analytics become valuable. Feed your data into an LLM and ask it to identify patterns. It will spot things you miss.
+
+### Month 5-8: Acceleration ($2,000-5,000/month)
+
+Add leverage:
+1. Create a second product or service tier
+2. Build partnerships with complementary businesses
+3. Invest in the content channels that proved most effective
+4. Automate the remaining manual touchpoints
+
+### Month 9-12: Scale ($5,000-10,000+/month)
+
+Compound what works:
+1. Double down on your best acquisition channel
+2. Raise prices (your results justify it)
+3. Add AI agents for customer support and onboarding
+4. Consider your first hire — or more AI automation
+
+The key insight: an AI-native business scales through better systems, not more hours. Every improvement to your automation multiplies output without multiplying your workload.
+
+## Common Mistakes That Kill AI-Native Businesses
+
+After observing dozens of AI-native business launches, these are the failure patterns that appear most frequently:
+
+**1. Tool tourism.** Spending weeks evaluating every AI tool instead of building with the first adequate option. The best tool is the one you actually use to ship something.
+
+**2. Perfecting AI output instead of shipping.** AI-generated content at 85% quality, published today, beats 98% quality content published never. Edit for accuracy and clarity. Stop editing for perfection.
+
+**3. Building in private.** The business does not exist until someone other than you has seen it. Launch ugly. Improve publicly. Your audience will forgive rough edges; they will not forgive invisibility.
+
+**4. Ignoring the human layer.** AI handles production. But trust, strategy, and authentic voice are human jobs. The businesses that win are the ones where the human provides clear strategic direction and genuine expertise, and AI executes at scale.
+
+**5. Treating AI as a replacement for understanding your customer.** AI can write emails. It cannot tell you what your customer actually cares about. Do the research. Talk to real people. Then let AI scale the insights you gather.
+
+## Revenue Models That Work With AI-Native Operations
+
+Let us get specific about how money flows in an AI-native business:
+
+### Recurring Revenue (Subscriptions/Retainers)
+
+**Best for:** Productized services, content businesses, SaaS
+
+A client pays $500-2,000/month for ongoing AI-powered deliverables. Your cost to fulfill is $20-50/month in AI tool costs. This is the highest-margin model and the most predictable revenue stream.
+
+### Digital Product Sales
+
+**Best for:** Course creators, template sellers, ebook authors
+
+One-time or tiered pricing for a digital product. AI helps you create the product faster, build the sales funnel, and handle post-purchase onboarding. Margins are 85-95%.
+
+### Affiliate and Ad Revenue
+
+**Best for:** Content businesses, niche sites
+
+AI produces content at scale. Traffic generates revenue through affiliate commissions or display ads. Lower revenue per visitor but high volume compensates. Best when combined with email list building for long-term value.
+
+### Consulting + AI Leverage
+
+**Best for:** Domain experts entering the AI-native space
+
+Premium pricing ($200-500/hour or $2,000-10,000/project) justified by AI-enhanced depth and speed of analysis. The AI does the research and initial analysis; you provide the strategic interpretation.
+
+For a detailed walkthrough of building an automated sales system, see our [AI sales funnel guide](/en/blog/ai-sales-funnel-guide-2026).
+
+## Real Numbers: What AI-Native Operating Costs Look Like
+
+Transparency matters. Here is what a typical AI-native business spends monthly at different revenue levels:
+
+| Revenue Level | AI Tools | Hosting/Infra | Marketing | Total Costs | Net Margin |
+|---|---|---|---|---|---|
+| $0-1K | $60 | $20 | $0 | $80 | Variable |
+| $1K-5K | $100 | $30 | $50 | $180 | 82-96% |
+| $5K-10K | $150 | $50 | $200 | $400 | 92-96% |
+| $10K-25K | $250 | $80 | $500 | $830 | 92-97% |
+
+These margins are not hypothetical. When your production costs are AI tool subscriptions instead of employee salaries, margin compression simply does not happen the same way it does in traditional businesses.
+
+## FAQ
+
+### How much money do I need to start an AI-native business?
+
+You can start with $60-100/month for essential tools: an LLM subscription ($20), an automation platform ($20-30), and email marketing (free tier for most platforms). No inventory, no office, no employees. The barrier to entry is knowledge and execution, not capital.
+
+### Do I need technical skills or coding experience?
+
+No. The 2026 tool ecosystem is designed for non-technical users. Automation platforms like Make and Zapier use visual interfaces. AI tools require prompt writing, not programming. That said, basic comfort with digital tools and willingness to learn new platforms is essential. If you can use Google Sheets and email, you can build an AI-native business.
+
+### How long does it take to generate meaningful revenue?
+
+Most AI-native businesses that follow a consistent execution plan see their first revenue within 30-60 days. Reaching $1,000/month typically takes 2-4 months. Reaching $5,000/month takes 4-8 months. These timelines assume you are working on the business 15-25 hours per week and producing content consistently.
+
+### What is the difference between an AI-native business and using AI tools in my existing business?
+
+An AI-native business is designed around AI from the beginning. The business model, pricing, operations, and growth strategy all assume AI handles the majority of production work. Using AI tools in an existing business means adding automation to processes that were designed for human execution. The structural difference affects everything: margins, scalability, time investment, and competitive positioning.
+
+### Can I run an AI-native business as a side project while keeping my full-time job?
+
+Yes, and many people do exactly this. The key advantage of AI-native businesses is that AI handles production even when you are not working. Expect to invest 10-15 hours per week during the first two months (setup and launch), then 5-10 hours per week for ongoing management and optimization. Content production, email sequences, and customer onboarding all run autonomously.
+
+### What happens when AI tools change or improve significantly?
+
+This is actually an advantage, not a risk. When AI capabilities improve, your business gets more capable without additional cost. A better LLM means higher quality content output. Better automation tools mean fewer manual touchpoints. The businesses at risk from AI improvement are the ones competing with AI — not the ones built on top of it.
+
+### What are the legal or ethical considerations for AI-native businesses?
+
+Three main areas to be aware of. First, disclosure: some jurisdictions and platforms require disclosure when content is AI-generated. Check local regulations. Second, accuracy: AI can produce plausible-sounding misinformation. You are responsible for fact-checking output, especially in regulated industries. Third, intellectual property: AI-generated content ownership is still evolving legally. Keep records of your prompts and editorial process as evidence of human creative direction.
+
+## What to Do Right Now
+
+You have read the guide. The temptation is to read three more guides, compare seven more tools, and "start next month when things are less busy."
+
+Do not do that. Do this instead:
+
+1. **Pick your model** — Choose one of the four models described above. Spend no more than 30 minutes deciding.
+2. **Start Day 1 of the 7-Day Launch Plan** — Today. Not tomorrow. Not next week.
+3. **[Download our free guide](/en/free-guide)** — It includes the prompt templates, automation blueprints, and email sequences referenced in this article.
+4. **Bookmark this page** — Come back to the scaling section when you have completed your first month.
+
+The difference between people who build AI-native businesses and people who talk about building AI-native businesses is exactly seven days of focused execution. Your seven days start now.

--- a/content/blog/one-person-business-with-ai-2026.md
+++ b/content/blog/one-person-business-with-ai-2026.md
@@ -1,0 +1,332 @@
+---
+title: "One-Person Business with AI: Complete Setup Guide for 2026"
+description: "How to build and run a profitable one-person business using AI in 2026. Covers the 5-step setup process, daily operations, tool stack, and answers to the most common questions."
+date: "2026-03-25"
+author: "AI Native Playbook"
+tags: ["solopreneur", "ai-tools", "one-person-business", "automation"]
+category: "AI Automation"
+readingTime: "14 min read"
+---
+
+Running a business alone used to mean choosing between two bad options: stay small and manageable, or try to scale and burn out. AI eliminated that tradeoff.
+
+In 2026, a single person with the right AI systems can operate a business that produces content like a media company, nurtures leads like a marketing team, and handles customer support like a dedicated service department — all while working 20-30 hours per week.
+
+This is not a vision statement. This is the operating reality for thousands of solopreneurs right now. This guide shows you exactly how to set it up.
+
+## Why One-Person Businesses Are Winning in 2026
+
+Before the how, the why — because understanding the structural advantage explains every decision that follows.
+
+**The margin advantage is enormous.** A traditional small business with three employees generating $15,000/month might net $3,000-5,000 after salaries and overhead. A one-person AI business generating $15,000/month nets $13,000-14,500. Same revenue, radically different economics.
+
+**Speed of execution is unmatched.** No meetings. No alignment sessions. No waiting for approvals. You identify an opportunity, build the response, and ship it — often within the same day. When AI handles production, your bottleneck is decision-making speed, and one person decides faster than any team.
+
+**Pivoting costs almost nothing.** If your current offer is not working, you change it. No layoffs, no restructuring, no team morale management. You update your prompts, revise your landing page, and test a new approach by tomorrow morning.
+
+**The tools caught up.** This is the real change. Two years ago, running a one-person business at scale required cobbling together fifteen different tools and writing custom code to connect them. Today, platforms like Make, Brevo, and modern LLMs provide native integrations that handle 90% of business operations without code.
+
+## The 5-Step Setup: From Zero to Operating Business
+
+This is not a theory section. Each step includes exactly what to do, which tools to use, and what "done" looks like.
+
+### Step 1: Define Your Revenue Engine
+
+Every business has one core mechanism that generates revenue. You need to define yours before touching a single tool.
+
+**Answer these three questions:**
+
+1. **What am I selling?** (A service, a digital product, a subscription, consulting)
+2. **Who is buying it?** (Be specific: "small business owners who need content" not "businesses")
+3. **How will they find me?** (SEO content, social media, partnerships, paid ads)
+
+**The constraint that matters:** Choose a model where AI can handle at least 70% of the fulfillment work. If you are selling custom graphic design that requires extensive back-and-forth with each client, AI cannot handle enough of the process yet. If you are selling AI-generated content packages, email marketing setup, or data analysis reports, you are in the right zone.
+
+**Example revenue engines that work for one-person AI businesses:**
+
+- Monthly content packages for small businesses ($500-2,000/client/month)
+- Digital courses or template packs ($47-497 per sale, automated delivery)
+- AI-powered consulting reports ($1,000-5,000 per project)
+- Niche content sites monetized through affiliate and ad revenue ($2,000-10,000/month)
+- [Automated sales funnels](/en/blog/ai-sales-funnel-guide-2026) selling digital products ($1,000-20,000/month)
+
+**Deliverable:** A single sentence describing your revenue engine. "I sell [thing] to [person] through [channel]."
+
+For more revenue model ideas, check our guide to [AI side hustles that generate real income](/en/blog/ai-side-hustle-ideas-2026).
+
+### Step 2: Build Your AI Production System
+
+This is the engine room. Your AI production system handles the repetitive, high-volume work that would otherwise require employees.
+
+**The core components:**
+
+**Content Production Pipeline**
+- **Primary LLM** (Claude or GPT-4o): Generates blog posts, email sequences, social media content, product descriptions, and customer communications
+- **Image Generation** (Midjourney or DALL-E): Creates visual content for blog headers, social posts, and product images
+- **Prompt Library**: Your collection of tested, refined prompts for each content type. This is your intellectual property — it is what makes your AI output better than someone else using the same tools
+
+**Automation Layer**
+- **Make or n8n**: Connects your LLM to your content management system, email platform, and social media scheduling tools
+- **Standard workflows to build:**
+  - Content brief enters system, AI generates draft, draft goes to review queue
+  - New subscriber triggers welcome email sequence (AI-written, pre-approved)
+  - Customer purchase triggers onboarding sequence
+  - Weekly analytics report generated and delivered to your dashboard
+
+**Quality Control Process**
+- AI generates at 85-90% quality. You provide the final 10-15%: fact-checking, brand voice alignment, strategic edits
+- Batch your review work: check all AI output once or twice daily, not continuously
+- Build feedback loops: when you edit AI output, save the corrections as examples for improved prompts
+
+**Time investment:** 8-12 hours to set up initially. 1-2 hours per day for ongoing review and optimization.
+
+For the complete solopreneur tool stack breakdown, read our [solopreneur AI stack guide](/en/blog/solopreneur-ai-stack).
+
+### Step 3: Set Up Customer Acquisition on Autopilot
+
+A one-person business cannot afford to spend 4 hours a day on marketing. Your customer acquisition needs to run with minimal daily input.
+
+**The three-channel approach:**
+
+**Channel 1: SEO Content (Long-term, compounding)**
+- AI produces 3-5 blog posts per week targeting specific keywords
+- Each post includes a call-to-action driving readers to your lead magnet or product
+- Results compound: a post published today continues driving traffic for years
+- Setup time: 4-6 hours. Ongoing time: 30 minutes/day for review
+
+**Channel 2: Email Marketing (Highest ROI)**
+- Lead magnet attracts email signups ([download our free guide](/en/free-guide) to see an example)
+- AI-written welcome sequence introduces your brand and offer over 5-7 emails
+- Ongoing newsletter keeps subscribers engaged (AI drafts, you review)
+- Platform: Brevo free tier handles up to 300 emails/day
+- Setup time: 3-4 hours. Ongoing time: 20 minutes/day
+
+**Channel 3: Social Media (Amplification)**
+- Repurpose blog content into social media posts (AI handles the reformatting)
+- Focus on one platform where your audience is most active
+- Schedule 1-2 weeks of content in advance
+- Setup time: 2-3 hours. Ongoing time: 15 minutes/day
+
+**Total daily marketing time: ~65 minutes.** Compare this to the 3-4 hours most solopreneurs spend on marketing. The difference is your AI production system handles the creation; you handle the strategy and review.
+
+### Step 4: Automate Sales and Delivery
+
+The sale should not require your presence. Neither should delivery.
+
+**Sales automation:**
+- Landing page clearly explains your offer and pricing
+- Payment processor (Paddle or Stripe) handles checkout
+- AI-written email sequences handle objections and drive conversions for leads who do not buy immediately
+- Upsell and cross-sell sequences trigger automatically after purchase
+
+**Delivery automation:**
+- Digital products: Automatic delivery via email after purchase
+- Services: Onboarding questionnaire sent automatically, AI generates initial deliverable based on responses
+- Courses: Drip-release schedule runs automatically
+- Consulting: Scheduling link (Calendly or Cal.com) sent post-purchase, AI prepares pre-call briefing
+
+**The key metric:** Time from purchase to first value delivered. For digital products, this should be under 5 minutes (instant download). For services, under 24 hours (automated onboarding + AI-generated first draft).
+
+### Step 5: Build Your Operations Dashboard
+
+You cannot optimize what you do not measure. And as a one-person operation, you cannot afford to spend an hour pulling reports from six different platforms.
+
+**Build a single dashboard that shows:**
+
+1. **Revenue metrics**: MRR, new sales, refund rate
+2. **Traffic metrics**: Website visitors, top-performing content, traffic sources
+3. **Email metrics**: List size, open rate, click rate, unsubscribe rate
+4. **Customer metrics**: New customers, support tickets, satisfaction signals
+
+**Tools:**
+- **Notion**: Central business dashboard. Use database views to track tasks, content calendar, and financial metrics
+- **Google Analytics 4**: Website traffic and conversion tracking
+- **Your email platform's dashboard**: Email performance metrics
+- **Stripe/Paddle dashboard**: Revenue metrics
+
+**The daily review ritual (15 minutes):**
+1. Check revenue dashboard: any new sales or refunds?
+2. Check email metrics: anything unusual in open/click rates?
+3. Review AI output queue: approve or edit pending content
+4. Check support inbox: handle any customer issues
+5. Update task list: what is the one thing that moves the needle today?
+
+This 15-minute review replaces the 2-3 hours of scattered admin work that kills most solopreneurs' productivity.
+
+## Daily Operations: What a Typical Day Looks Like
+
+Here is what running a one-person AI business actually looks like on a daily basis:
+
+### Morning Block (1-2 hours): Strategy and Review
+
+- 15 minutes: Dashboard review (metrics, alerts, customer messages)
+- 30 minutes: Review and approve AI-generated content in the queue
+- 15-30 minutes: Strategic work — product improvement, new offer development, partnership outreach
+- 15 minutes: Set AI tasks for the day (new content briefs, email sequences to generate)
+
+### Midday: AI Works, You Don't
+
+- Your content pipeline produces and schedules posts
+- Email sequences nurture leads automatically
+- Sales pages collect orders and trigger delivery workflows
+- Customer onboarding runs without intervention
+
+### Afternoon Block (1-2 hours): High-Value Work
+
+- Deep work on product creation or improvement
+- Customer conversations that require a human touch
+- Testing and optimizing: A/B test results, funnel adjustments
+- Learning: staying current on AI tools and industry trends
+
+### End of Day (30 minutes): Setup for Tomorrow
+
+- Review the day's performance against goals
+- Queue up AI tasks for overnight/next morning production
+- Handle any remaining customer communications
+- Update your task list
+
+**Total working time: 3-5 hours per day.** The rest of the time, your AI systems operate independently. This is not about working less for the sake of working less — it is about concentrating your limited human attention on the decisions and relationships that only a human can handle.
+
+## Scaling a One-Person Business Without Hiring
+
+The natural instinct when revenue grows is to hire. Resist that instinct until you have exhausted every automation option. Here is how to scale without adding headcount:
+
+### Level 1: Better Prompts ($0 cost)
+
+Your first scaling lever is free. Better prompts produce higher quality output, which means less editing time, which means higher throughput. Invest 2-3 hours per month refining your prompt library. Save every successful prompt variation. Delete every prompt that requires heavy editing.
+
+### Level 2: More Automation ($20-50/month additional)
+
+Add automation for tasks you are still doing manually:
+- Social media scheduling
+- Invoice generation
+- Customer feedback collection
+- Analytics reporting
+
+Each automation you add recovers 30-60 minutes per week. After five automations, you have recovered an entire working day.
+
+### Level 3: AI Agents ($50-100/month additional)
+
+Deploy AI agents for tasks that require judgment but not your specific judgment:
+- Customer support triage (AI answers common questions, escalates unusual ones to you)
+- Content quality scoring (AI reviews drafts against your style guide)
+- Lead qualification (AI scores inbound leads based on criteria you define)
+
+### Level 4: Strategic Contractors (Variable cost)
+
+When you genuinely cannot automate further, bring in specialists for specific tasks — not employees, contractors. A designer for brand work. A developer for custom integrations. A strategist for quarterly planning. Pay per deliverable, not per hour.
+
+**The decision rule:** Do not hire or contract until you can clearly articulate what the person will do that AI cannot. If you cannot articulate it clearly, the answer is better automation, not more people.
+
+## The Financial Reality: Months 1-12
+
+Here is an honest timeline of what to expect financially:
+
+### Months 1-2: Investment Phase
+
+- **Revenue:** $0-500
+- **Costs:** $80-150/month (tools)
+- **Net:** Negative or break-even
+- **Focus:** Building systems, creating initial content, getting first customers
+
+This is the hardest phase psychologically. Your systems are running but the audience has not found you yet. Keep producing content. Keep optimizing your funnel. The compound effect has not kicked in yet.
+
+### Months 3-4: Validation Phase
+
+- **Revenue:** $500-2,000/month
+- **Costs:** $100-200/month
+- **Net:** $300-1,800/month
+- **Focus:** Doubling down on what is working, cutting what is not
+
+You have data now. Some content performs well. Some emails convert. Follow the signal, not your assumptions.
+
+### Months 5-8: Growth Phase
+
+- **Revenue:** $2,000-7,000/month
+- **Costs:** $150-300/month
+- **Net:** $1,700-6,700/month
+- **Focus:** Scaling proven channels, adding products/services, raising prices
+
+This is where the one-person AI advantage becomes obvious. Your costs barely increase while revenue grows. Every dollar of revenue growth drops almost entirely to profit.
+
+### Months 9-12: Acceleration Phase
+
+- **Revenue:** $5,000-15,000+/month
+- **Costs:** $200-500/month
+- **Net:** $4,500-14,500+/month
+- **Focus:** Optimization, premium offerings, strategic partnerships
+
+At this stage, you are running a business that matches the output of a small agency — with the cost structure of a freelancer and the margins of a software company.
+
+## Mistakes That Sink One-Person AI Businesses
+
+Learn from the failures so you do not repeat them:
+
+**1. Building a business around a single AI tool.** If your entire business depends on one specific AI platform, you are one API change away from disaster. Build tool-agnostic workflows where the LLM is interchangeable.
+
+**2. Automating before validating.** Do not spend three weeks building a perfect automation pipeline for a product nobody wants. Sell it manually first. Once you have paying customers, then automate the delivery.
+
+**3. Neglecting the human touchpoints.** The emails customers remember are the ones that feel personal. The support interactions that create loyalty are the ones where a real human responded thoughtfully. Automate the routine. Be human for the moments that matter.
+
+**4. Comparing yourself to funded startups.** A funded startup with 10 employees and $2M in capital will outpace you on feature development. They will not outpace you on margin, speed of pivoting, or capital efficiency. Play your game, not theirs.
+
+**5. Chasing every new AI tool.** A new AI tool launches every day. Most are irrelevant to your business. Evaluate new tools quarterly, not daily. The best operators are disciplined about what they ignore.
+
+**6. Underpricing because you are "just one person."** Your clients pay for results, not headcount. If your AI-powered service delivers the same or better outcome as an agency, price it at 60-80% of agency rates — not at freelancer rates. The fact that AI does the production work is your margin advantage, not a discount reason.
+
+## Advanced Tactics for Experienced Solo Operators
+
+Once your foundation is solid, these tactics accelerate growth:
+
+**Build in public.** Share your journey, your numbers (selectively), and your process. This attracts customers who want the same results and positions you as an authority in your space. AI can help you draft the content; the transparency and authenticity are yours.
+
+**Create an ecosystem, not a single product.** Your blog feeds your email list. Your email list sells your course. Your course graduates become consulting clients. Your consulting insights improve your blog content. Each element strengthens the others.
+
+**Develop proprietary AI workflows.** The longer you operate, the more refined your prompts, automation sequences, and quality control processes become. This is genuine intellectual property. Consider productizing your best workflows as a secondary revenue stream.
+
+**Join or create a mastermind.** The biggest risk of working alone is blind spots. A small group of 3-5 other solo operators meeting monthly provides perspective, accountability, and strategic input that no AI can replace.
+
+## FAQ
+
+### Is it really possible to run a profitable business completely alone with AI?
+
+Yes, and it is happening at scale. The key word is "completely alone" — meaning no employees. You will still interact with customers, contractors for specialized tasks, and possibly partners. What AI replaces is the ongoing operational staff: content writers, marketing assistants, customer support agents, and administrative assistants. A single person with AI systems can match the output that required 3-5 employees two years ago.
+
+### What types of businesses work best as one-person AI operations?
+
+Digital-first businesses with knowledge-based products and services. The best fits are: content businesses (blogs, newsletters, courses), productized services (recurring deliverables for clients), digital product sales (templates, tools, guides), and consulting with AI-enhanced delivery. Businesses that require physical inventory, in-person service, or heavy regulatory compliance are harder to run solo, though AI still helps with their marketing and operations.
+
+### How do I handle customer support as a one-person operation?
+
+Three layers. First, AI-powered self-service: FAQ pages, knowledge bases, and chatbots handle 60-70% of inquiries without your involvement. Second, AI-assisted responses: for email support, AI drafts responses based on your previous answers and tone. You review and send, cutting response time by 80%. Third, direct human interaction: for complex issues, refund requests, and high-value client concerns, you handle them personally. Most one-person businesses can manage support in 30 minutes per day using this layered approach.
+
+### What if my AI systems produce errors or low-quality output?
+
+Build quality gates into your workflows. Never let AI output go directly to customers without review. The standard approach: AI generates, you review in batches (twice daily), approved content publishes automatically. For customer-facing communications, start with AI drafts and manual sending until you trust the output quality. Gradually automate as your prompts improve. Keep a swipe file of corrections — it is the fastest way to improve prompt quality over time.
+
+### How do I stay competitive when everyone has access to the same AI tools?
+
+Three differentiators that AI cannot commoditize. First, your expertise and perspective: AI is a production tool. The strategic thinking, industry knowledge, and unique point of view come from you. Second, your system design: how you connect tools, structure prompts, and design workflows is proprietary, even if the individual tools are public. Third, your relationships: trust, reputation, and customer relationships are built by humans. Focus on these three and you remain competitive regardless of which AI tools others use.
+
+### What is the minimum time commitment per week to run a one-person AI business?
+
+During setup (first 2-4 weeks): 15-25 hours per week. This includes building your production systems, creating initial content, and setting up automation. During steady-state operations: 10-20 hours per week, depending on your business model and growth ambitions. The minimum viable time commitment is about 10 hours per week — enough for daily review, content approval, customer interaction, and strategic planning. Below that, quality and growth tend to suffer.
+
+### Should I start with a free tool stack or invest in paid tools from day one?
+
+Start with a hybrid approach. Some tools have excellent free tiers that are sufficient for launch: Brevo (email, 300 emails/day free), Google Analytics (free), Notion (free for personal use). Other tools require paid plans from the start: your LLM subscription ($20/month), your automation platform ($20-30/month for useful features). Total minimum viable spend: $40-60/month. Do not let tool costs be the reason you do not start. A coffee shop habit costs more than an AI-native business infrastructure.
+
+## Your Next Step
+
+You now have the complete picture: the business models that work, the 5-step setup process, the daily operations framework, the scaling path, and the mistakes to avoid.
+
+The next move is yours.
+
+1. **Complete Step 1 today** — Define your revenue engine in one sentence
+2. **[Get the free setup guide](/en/free-guide)** — Includes prompt templates, automation blueprints, and the complete tool comparison matrix
+3. **Start Step 2 tomorrow** — Build your first AI production workflow
+4. **Revisit this guide weekly** — Use it as a checklist as you progress through each step and scaling phase
+
+The gap between one-person businesses that succeed and those that stall is not talent, capital, or luck. It is the speed at which you move from reading to building. The AI handles the production. You handle the decision to start.
+
+Start today.


### PR DESCRIPTION
## Summary
- Add "How to Start an AI-Native Business in 2026" (3,100+ words, published 2026-03-24)
- Add "One-Person Business with AI: Complete Setup Guide" (3,200+ words, published 2026-03-25)
- Both posts include 7-Day Launch Plan / 5-Step Setup sections, 7 FAQ Q&As each
- Internal links to /ai-side-hustles, /solopreneur-ai-stack, /ai-sales-funnel-guide
- CTAs to /free-guide
- Content created by Gary (CMO), formatted for blog system

## Test plan
- [x] `npm run build` passes
- [ ] Verify posts render correctly on staging
- [ ] Check internal links resolve
- [ ] Check FAQ schema rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)