### PR TITLE
fix: persist blog posts to GitHub across Vercel redeploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,9 @@ SENTRY_PROJECT=ai-architect-global
 # PostHog Analytics
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# ─────────────────────────────────────────────────────
+# GitHub (blog post persistence across Vercel deploys)
+# ─────────────────────────────────────────────────────
+GITHUB_TOKEN=ghp_your-personal-access-token
+GITHUB_BLOG_BRANCH=main

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -5,6 +5,29 @@ import { revalidatePath } from "next/cache";
 
 const BLOG_DIR = path.join(process.cwd(), "content/blog");
 
+/** Fire-and-forget: commit the markdown file to GitHub so it survives Vercel redeploys. */
+function commitToGitHub(slug: string, content: string): void {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return;
+  const branch = process.env.GITHUB_BLOG_BRANCH || "main";
+  const filePath = `content/blog/${slug}.md`;
+  const url = `https://api.github.com/repos/migkjy/ai-architect-global/contents/${filePath}`;
+
+  fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      message: `blog: add ${slug}`,
+      content: Buffer.from(content).toString("base64"),
+      branch,
+    }),
+  }).catch((err) => console.error("[blog/commitToGitHub]", err));
+}
+
 function checkAuth(req: NextRequest): boolean {
   const apiKey = req.headers.get("x-api-key");
   return apiKey === process.env.BLOG_API_KEY;
@@ -95,6 +118,9 @@ export async function POST(req: NextRequest) {
     }
 
     fs.writeFileSync(filePath, fileContent, "utf-8");
+
+    // Persist to GitHub so the file survives Vercel redeploys
+    commitToGitHub(slug, fileContent);
 
     // ISR 재검증 트리거
     revalidatePath("/en/blog");


### PR DESCRIPTION
## Summary
- Blog posts created via the `/api/blog/posts` API were lost whenever Vercel redeployed because Vercel provisions a fresh filesystem from git.
- After writing the markdown file to disk, the API now also commits it to GitHub via the Contents API (fire-and-forget, non-blocking).
- Added `GITHUB_TOKEN` and `GITHUB_BLOG_BRANCH` env vars to `.env.example`.

## Test plan
- [ ] Set `GITHUB_TOKEN` (PAT with repo scope) in Vercel env vars
- [ ] POST a new blog post via the API
- [ ] Verify the markdown file appears in the GitHub repo under `content/blog/`
- [ ] Verify the API still returns 201 even if `GITHUB_TOKEN` is unset (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)