### PR TITLE
feat(ainp): 301 redirect ai-driven-architect.com → ai-native-playbook.com

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,7 +37,20 @@ const nextConfig: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
   async redirects() {
-    return [];
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "ai-driven-architect.com" }],
+        destination: "https://ai-native-playbook.com/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.ai-driven-architect.com" }],
+        destination: "https://ai-native-playbook.com/:path*",
+        permanent: true,
+      },
+    ];
   },
   async rewrites() {
     return [


### PR DESCRIPTION
## Summary
- Add host-based 301 permanent redirects in `next.config.ts`
- Redirects both `ai-driven-architect.com` and `www.ai-driven-architect.com` to `https://ai-native-playbook.com` preserving the original path
- Uses Next.js built-in `redirects()` config with `has: [{ type: 'host' }]` matcher

## Test plan
- [ ] Verify Vercel preview build succeeds
- [ ] After staging deploy, test with `curl -I -H "Host: ai-driven-architect.com" <staging-url>` to confirm 301 response
- [ ] Confirm existing ai-native-playbook.com requests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain redirects now configured to automatically route traffic from legacy domains to the new domain.
  * All original page paths are preserved during redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->