### PR TITLE
fix: Paddle checkout stuck on Preparing checkout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -256,9 +256,9 @@ export default async function LocaleLayout({
           <>
             <Script
               src="https://cdn.paddle.com/paddle/v2/paddle.js"
-              strategy="lazyOnload"
+              strategy="afterInteractive"
             />
-            <Script id="paddle-init" strategy="lazyOnload">
+            <Script id="paddle-init" strategy="afterInteractive">
               {`
                 (function() {
                   var checkPaddle = setInterval(function() {

--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -68,8 +68,8 @@ export default function BuyButton({
       if (checkPaddle()) clearInterval(interval);
     }, 300);
 
-    // 4초 후 포기 (Paddle.js 미로드 = Client Token 미설정)
-    const timeout = setTimeout(() => clearInterval(interval), 4000);
+    // 10초 후 포기 (Paddle.js 미로드 = Client Token 미설정)
+    const timeout = setTimeout(() => clearInterval(interval), 10000);
 
     return () => {
       clearInterval(interval);

--- a/src/components/StickyMobileCTA.tsx
+++ b/src/components/StickyMobileCTA.tsx
@@ -44,7 +44,7 @@ export default function StickyMobileCTA({
     const interval = setInterval(() => {
       if (checkPaddle()) clearInterval(interval);
     }, 300);
-    const timeout = setTimeout(() => clearInterval(interval), 4000);
+    const timeout = setTimeout(() => clearInterval(interval), 10000);
     return () => {
       clearInterval(interval);
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- **Root cause**: Paddle.js was loaded with Next.js `strategy="lazyOnload"`, which defers script loading until after the page becomes idle. The BuyButton and StickyMobileCTA components poll for `window.Paddle.Checkout` for only 4 seconds before giving up — but `lazyOnload` often takes longer, leaving buttons permanently stuck showing "Preparing checkout..."
- Changed Paddle.js script strategy from `lazyOnload` to `afterInteractive` so it loads during hydration
- Increased polling timeout from 4s to 10s as a safety net for slow connections

## Files changed
- `src/app/[locale]/layout.tsx` — script strategy change
- `src/components/BuyButton.tsx` — timeout 4s → 10s
- `src/components/StickyMobileCTA.tsx` — timeout 4s → 10s

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Deploy to staging preview
- [ ] Confirm buy buttons show actual CTA text (not "Preparing checkout...")
- [ ] Confirm Paddle overlay checkout opens on click
- [ ] Test on slow 3G throttled connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Paddle Billing script loading timing for faster payment processing.
  * Extended checkout initialization polling to improve reliability and reduce timeout errors during payment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->