### PR TITLE
fix(seo): canonical URL /en/ prefix + internal links + meta optimization

### DIFF
--- a/content/blog/ai-marketing-strategy-2026.md
+++ b/content/blog/ai-marketing-strategy-2026.md
@@ -2,6 +2,7 @@
 title: "AI Marketing Strategy 2026: Step-by-Step Framework"
 description: "Build a complete AI marketing strategy using Russell Brunson and Jeff Walker frameworks. Actionable steps for entrepreneurs and small business owners."
 date: "2026-03-07"
+updated: "2026-03-24"
 category: "AI Marketing"
 tags: ["AI marketing strategy", "AI marketing 2026", "marketing automation", "AI business framework", "Russell Brunson AI", "digital marketing AI"]
 locale: "en"
@@ -40,6 +41,8 @@ Instead of guessing what to say when, give AI the PLF framework and your product
 - Social proof integration points
 - Scarcity and urgency triggers timed to your launch calendar
 - Post-launch follow-up for non-buyers
+
+If you want to go deeper on the email side, [AI email automation for solopreneurs](/en/blog/ai-email-automation-for-solopreneurs) covers the full sequence architecture and prompt system that makes these sequences convert.
 
 ### Step 3: Write Copy That Converts
 

--- a/content/blog/ai-sales-funnel-guide-2026.md
+++ b/content/blog/ai-sales-funnel-guide-2026.md
@@ -2,6 +2,7 @@
 title: "Build an AI Sales Funnel in 2026 — Complete Guide"
 description: "Step-by-step guide to building an automated AI sales funnel that captures leads, nurtures prospects, and closes sales — without a full marketing team."
 date: "2026-03-13"
+updated: "2026-03-24"
 author: "AI Native Playbook"
 tags: ["AI sales funnel", "automated sales funnel", "AI funnel builder", "sales automation", "AI marketing"]
 category: "AI Marketing"
@@ -117,7 +118,7 @@ You do not need sophisticated automation for this. Most email platforms support 
 
 ### The Sales Page Structure That Works in 2026
 
-Long-form sales pages still outperform short pages for offers above $47. The structure, adapted from Russell Brunson's DotCom Secrets framework:
+Long-form sales pages still outperform short pages for offers above $47. The structure, adapted from [Russell Brunson's DotCom Secrets framework](/en/blog/russell-brunson-ai-framework):
 
 1. **Attention headline** — The transformation, not the product
 2. **Agitation section** — Name the specific frustrations the reader feels right now

--- a/content/blog/ai-tools-for-small-business-2026.md
+++ b/content/blog/ai-tools-for-small-business-2026.md
@@ -2,6 +2,7 @@
 title: "Best AI Tools for Small Business in 2026 — Complete Guide"
 description: "ChatGPT, Claude, and other AI tools compared for small business owners. Practical guide to choosing and using AI to save time and grow revenue."
 date: "2026-02-18"
+updated: "2026-03-24"
 category: "AI Tools"
 tags: ["AI tools", "small business", "ChatGPT", "Claude", "productivity"]
 locale: "en"

--- a/content/blog/product-launch-formula-ai.md
+++ b/content/blog/product-launch-formula-ai.md
@@ -73,6 +73,6 @@ A PLF launch is not a one-time event. It's a system. Once you've run the sequenc
 
 AI gets you to "first launch" faster. The frameworks handle the strategy. You handle the relationships.
 
-Before you dive into PLF, make sure you have the fundamentals. Our [free AI starter guide](/en/free-guide) covers the core automation framework and includes prompts you can use in your pre-launch content.
+Before you dive into PLF, make sure you have the fundamentals in place. PLF works best when paired with a solid Hook-Story-Offer architecture for the launch emails. The [Russell Brunson AI framework guide](/en/blog/russell-brunson-ai-framework) covers the Soap Opera Sequence and Value Ladder that feed directly into the PLF open-cart phase. Our [free AI starter guide](/en/free-guide) also covers the core automation framework and includes prompts you can use in your pre-launch content.
 
 The [AI Native Playbook Series](/en/products) includes an AI-powered PLF tool that walks you through each phase with prompts, templates, and guidance built directly into the workflow — so you're executing the framework, not just reading about it. See how it fits alongside other proven frameworks in our [patterns library](/en/patterns).

--- a/content/blog/russell-brunson-ai-framework.md
+++ b/content/blog/russell-brunson-ai-framework.md
@@ -2,6 +2,7 @@
 title: "Russell Brunson's DotCom Secrets with AI — Guide"
 description: "Apply Russell Brunson's Value Ladder, Hook-Story-Offer, and Soap Opera Sequence using AI tools. Step-by-step guide for online entrepreneurs."
 date: "2026-02-21"
+updated: "2026-03-24"
 category: "AI Marketing"
 tags: ["Russell Brunson", "DotCom Secrets", "AI funnel", "Value Ladder", "marketing"]
 locale: "en"
@@ -79,7 +80,9 @@ The DotCom Secrets frameworks work because they're built on timeless psychology.
 
 The businesses that win with these frameworks are the ones that ship consistently. They test more hooks. They run more sequences. They iterate faster than competitors who are still working on their first version.
 
-AI makes iteration fast enough that consistency becomes achievable for a one-person business. That's the real advantage.
+AI makes iteration fast enough that consistency becomes achievable for a one-person business. That's the real advantage. Once you have the email sequence running, the next step is connecting it to a complete [AI sales funnel](/en/blog/ai-sales-funnel-guide-2026) that moves leads from opt-in to purchase automatically.
+
+For a broader view of how these frameworks fit together into a cohesive system, the [AI marketing strategy guide](/en/blog/ai-marketing-strategy-2026) covers how Value Ladder, PLF, and copywriting frameworks operate in parallel.
 
 Want to see how these frameworks compare before committing? Our [free AI business guide](/en/free-guide) breaks down all six frameworks in a side-by-side chart and gives you 3 prompts to try today.
 

--- a/content/blog/solopreneur-ai-stack-2026.md
+++ b/content/blog/solopreneur-ai-stack-2026.md
@@ -2,6 +2,7 @@
 title: "The Solopreneur AI Stack: 10 Tools That Replace a Full Team"
 description: "The exact AI tool stack that lets one-person businesses compete with full teams — covering marketing, sales, customer service, content, and operations."
 date: "2026-03-13"
+updated: "2026-03-24"
 author: "AI Native Playbook"
 tags: ["solopreneur AI tools", "AI tool stack", "one-person business AI", "productivity", "small business AI"]
 category: "AI Tools"

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -28,7 +28,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!post) return {};
 
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
-  const canonicalUrl = `${siteUrl}/blog/${slug}`;
+  const canonicalUrl = locale === "en"
+    ? `${siteUrl}/en/blog/${slug}`
+    : `${siteUrl}/${locale}/blog/${slug}`;
 
   return {
     title: post.title,
@@ -74,10 +76,10 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${siteUrl}/blog/${slug}`,
+        en: `${siteUrl}/en/blog/${slug}`,
         ko: `${siteUrl}/ko/blog/${slug}`,
         ja: `${siteUrl}/ja/blog/${slug}`,
-        "x-default": canonicalUrl,
+        "x-default": `${siteUrl}/en/blog/${slug}`,
       },
     },
     robots: {
@@ -144,7 +146,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       width: 1200,
       height: 630,
     },
-    url: `${siteUrl}/blog/${slug}`,
+    url: locale === "en" ? `${siteUrl}/en/blog/${slug}` : `${siteUrl}/${locale}/blog/${slug}`,
     inLanguage: locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US",
     author: {
       "@type": "Organization",
@@ -164,7 +166,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     },
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${siteUrl}/blog/${slug}`,
+      "@id": locale === "en" ? `${siteUrl}/en/blog/${slug}` : `${siteUrl}/${locale}/blog/${slug}`,
     },
     keywords: post.tags.join(", "),
     wordCount: Math.round(post.content.split(/\s+/).length),
@@ -179,8 +181,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "AI Native Playbook Series", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: "Blog", item: `${siteUrl}/blog` },
-      { "@type": "ListItem", position: 3, name: post.title, item: `${siteUrl}/blog/${slug}` },
+      { "@type": "ListItem", position: 2, name: "Blog", item: `${siteUrl}/${locale}/blog` },
+      { "@type": "ListItem", position: 3, name: post.title, item: locale === "en" ? `${siteUrl}/en/blog/${slug}` : `${siteUrl}/${locale}/blog/${slug}` },
     ],
   };
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -31,7 +31,7 @@ const blogMeta: Record<string, { title: string; description: string; ogDescripti
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   const meta = blogMeta[locale] ?? blogMeta.en;
-  const canonicalUrl = locale === "en" ? `${SITE_URL}/blog` : `${SITE_URL}/${locale}/blog`;
+  const canonicalUrl = locale === "en" ? `${SITE_URL}/en/blog` : `${SITE_URL}/${locale}/blog`;
   return {
     title: meta.title,
     description: meta.description,
@@ -54,9 +54,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${SITE_URL}/blog`,
+        en: `${SITE_URL}/en/blog`,
         ja: `${SITE_URL}/ja/blog`,
-        "x-default": `${SITE_URL}/blog`,
+        "x-default": `${SITE_URL}/en/blog`,
       },
     },
     openGraph: {
@@ -122,7 +122,7 @@ export default async function BlogPage({
   const categories = Array.from(new Set(posts.map((p) => p.category))).sort();
   const topTags = getAllTags();
 
-  const canonicalUrl = locale === "en" ? `${SITE_URL}/blog` : `${SITE_URL}/${locale}/blog`;
+  const canonicalUrl = locale === "en" ? `${SITE_URL}/en/blog` : `${SITE_URL}/${locale}/blog`;
   const dateLocale = locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US";
 
   const collectionPageJsonLd = {
@@ -150,7 +150,7 @@ export default async function BlogPage({
       description: post.description,
       datePublished: post.date,
       dateModified: post.date,
-      url: `${SITE_URL}/blog/${post.slug}`,
+      url: `${SITE_URL}/${locale}/blog/${post.slug}`,
       keywords: post.tags.join(", "),
       author: {
         "@type": "Organization",
@@ -170,7 +170,7 @@ export default async function BlogPage({
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "AI Native Playbook Series", item: SITE_URL },
-      { "@type": "ListItem", position: 2, name: "Blog", item: `${SITE_URL}/blog` },
+      { "@type": "ListItem", position: 2, name: "Blog", item: `${SITE_URL}/${locale}/blog` },
     ],
   };
 

--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -25,7 +25,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!book) return {};
 
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
-  const canonicalUrl = `${siteUrl}/products/${slug}`;
+  const canonicalUrl = locale === "en"
+    ? `${siteUrl}/en/products/${slug}`
+    : `${siteUrl}/${locale}/products/${slug}`;
   return {
     title: `${book.title} — ${book.subtitle}`,
     description: book.shortDescription,
@@ -47,10 +49,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${siteUrl}/products/${slug}`,
+        en: `${siteUrl}/en/products/${slug}`,
         ko: `${siteUrl}/ko/products/${slug}`,
         ja: `${siteUrl}/ja/products/${slug}`,
-        "x-default": canonicalUrl,
+        "x-default": `${siteUrl}/en/products/${slug}`,
       },
     },
     openGraph: {


### PR DESCRIPTION
## Summary
- Fix canonical URLs missing /en/ prefix on blog posts and product pages (affects blog listing, blog slugs, product slugs)
- Fix alternates hreflang and JSON-LD structured data URLs to use correct locale prefixes
- Add 5 internal cross-links in Russell Brunson cluster posts
- Add `updated: "2026-03-24"` frontmatter to 5 blog posts

## Changed files (9 files — clean scope)

**Canonical URL fix (3 files):**
- `src/app/[locale]/blog/[slug]/page.tsx`
- `src/app/[locale]/blog/page.tsx`
- `src/app/[locale]/products/[slug]/page.tsx`

**Blog content — internal links + updated dates (6 files):**
- `content/blog/russell-brunson-ai-framework.md`
- `content/blog/ai-sales-funnel-guide-2026.md`
- `content/blog/ai-marketing-strategy-2026.md`
- `content/blog/product-launch-formula-ai.md`
- `content/blog/solopreneur-ai-stack-2026.md`
- `content/blog/ai-tools-for-small-business-2026.md`

Cherry-picked from #236 (scope-reduced per VP directive — #236 had 58 files, this PR is 9 files)

## Test plan
- [ ] Verify canonical URLs include /en/ prefix (e.g., /en/blog/slug not /blog/slug)
- [ ] Check sitemap and hreflang URLs use correct locale prefix
- [ ] Confirm internal links render correctly in blog posts
- [ ] Verify updated dates appear in post metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post metadata with recent publication dates and added internal linking references to related content for improved navigation.

* **Bug Fixes**
  * Corrected canonical URL generation for blog and product pages to properly include locale path prefixes (e.g., `/en/blog`) for improved SEO and multi-language support across structured data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->