### PR TITLE
fix(ainp): 비블로그 페이지 canonical URL locale prefix 수정

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
   const meta = aboutMeta[locale] ?? aboutMeta.en;
-  const canonicalUrl = locale === "en" ? `${siteUrl}/about` : `${siteUrl}/${locale}/about`;
+  const canonicalUrl = `${siteUrl}/${locale}/about`;
 
   return {
     title: meta.title,
@@ -41,10 +41,10 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${siteUrl}/about`,
+        en: `${siteUrl}/en/about`,
         ko: `${siteUrl}/ko/about`,
         ja: `${siteUrl}/ja/about`,
-        "x-default": `${siteUrl}/about`,
+        "x-default": `${siteUrl}/en/about`,
       },
     },
     openGraph: {

--- a/src/app/[locale]/bundle/page.tsx
+++ b/src/app/[locale]/bundle/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
   const meta = bundleMeta[locale] ?? bundleMeta.en;
-  const canonicalUrl = locale === "en" ? `${siteUrl}/bundle` : `${siteUrl}/${locale}/bundle`;
+  const canonicalUrl = `${siteUrl}/${locale}/bundle`;
 
   return {
     title: meta.title,
@@ -50,9 +50,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${siteUrl}/bundle`,
+        en: `${siteUrl}/en/bundle`,
         ja: `${siteUrl}/ja/bundle`,
-        "x-default": `${siteUrl}/bundle`,
+        "x-default": `${siteUrl}/en/bundle`,
       },
     },
     openGraph: {

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -9,7 +9,7 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playboo
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "faqPage" });
-  const canonicalUrl = locale === "en" ? `${SITE_URL}/faq` : `${SITE_URL}/${locale}/faq`;
+  const canonicalUrl = `${SITE_URL}/${locale}/faq`;
 
   return {
     title: t("title"),
@@ -28,10 +28,10 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${SITE_URL}/faq`,
+        en: `${SITE_URL}/en/faq`,
         ko: `${SITE_URL}/ko/faq`,
         ja: `${SITE_URL}/ja/faq`,
-        "x-default": `${SITE_URL}/faq`,
+        "x-default": `${SITE_URL}/en/faq`,
       },
     },
     openGraph: {
@@ -127,7 +127,7 @@ export default async function FaqPage({ params }: { params: Promise<{ locale: st
     ],
   };
 
-  const canonicalFaqUrl = locale === "en" ? `${SITE_URL}/faq` : `${SITE_URL}/${locale}/faq`;
+  const canonicalFaqUrl = `${SITE_URL}/${locale}/faq`;
 
   const faqJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -14,10 +14,7 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const canonicalUrl =
-    locale === "en"
-      ? `${SITE_URL}/free-guide`
-      : `${SITE_URL}/${locale}/free-guide`;
+  const canonicalUrl = `${SITE_URL}/${locale}/free-guide`;
 
   return {
     title: "Free AI Business Automation Starter Guide",
@@ -26,9 +23,9 @@ export async function generateMetadata({
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${SITE_URL}/free-guide`,
+        en: `${SITE_URL}/en/free-guide`,
         ja: `${SITE_URL}/ja/free-guide`,
-        "x-default": `${SITE_URL}/free-guide`,
+        "x-default": `${SITE_URL}/en/free-guide`,
       },
     },
     openGraph: {
@@ -104,10 +101,7 @@ export default async function FreeGuidePage({
   setRequestLocale(locale);
   const t = await getTranslations("freeGuide");
 
-  const canonicalUrl =
-    locale === "en"
-      ? `${SITE_URL}/free-guide`
-      : `${SITE_URL}/${locale}/free-guide`;
+  const canonicalUrl = `${SITE_URL}/${locale}/free-guide`;
 
   const courseJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/free-guide/thank-you/page.tsx
+++ b/src/app/[locale]/free-guide/thank-you/page.tsx
@@ -13,10 +13,7 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const canonicalUrl =
-    locale === "en"
-      ? `${SITE_URL}/free-guide/thank-you`
-      : `${SITE_URL}/${locale}/free-guide/thank-you`;
+  const canonicalUrl = `${SITE_URL}/${locale}/free-guide/thank-you`;
 
   return {
     title: "Thank You — Your Free Guide is Ready",

--- a/src/app/[locale]/getting-started/page.tsx
+++ b/src/app/[locale]/getting-started/page.tsx
@@ -11,9 +11,7 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playboo
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/getting-started`
-    : `${SITE_URL}/${locale}/getting-started`;
+  const canonicalUrl = `${SITE_URL}/${locale}/getting-started`;
 
   return {
     title: "Getting Started — AI Native Playbook Series",
@@ -75,9 +73,7 @@ export default async function GettingStartedPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/getting-started`
-    : `${SITE_URL}/${locale}/getting-started`;
+  const canonicalUrl = `${SITE_URL}/${locale}/getting-started`;
 
   const howToJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const ogLocale = OG_LOCALE_MAP[locale] ?? "en_US";
-  const pageUrl = locale === "en" ? SITE_URL : `${SITE_URL}/${locale}`;
+  const pageUrl = `${SITE_URL}/${locale}`;
 
   return {
     metadataBase: new URL(SITE_URL),
@@ -106,10 +106,10 @@ export async function generateMetadata({
     alternates: {
       canonical: pageUrl,
       languages: {
-        en: SITE_URL,
+        en: `${SITE_URL}/en`,
         ko: `${SITE_URL}/ko`,
         ja: `${SITE_URL}/ja`,
-        "x-default": SITE_URL,
+        "x-default": `${SITE_URL}/en`,
       },
     },
   };

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
   const meta = homeMeta[locale] ?? homeMeta.en;
-  const canonicalUrl = locale === "en" ? siteUrl : `${siteUrl}/${locale}`;
+  const canonicalUrl = `${siteUrl}/${locale}`;
   const ogLocale = locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US";
 
   return {
@@ -85,10 +85,10 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: siteUrl,
+        en: `${siteUrl}/en`,
         ko: `${siteUrl}/ko`,
         ja: `${siteUrl}/ja`,
-        "x-default": siteUrl,
+        "x-default": `${siteUrl}/en`,
       },
     },
   };

--- a/src/app/[locale]/patterns/[slug]/page.tsx
+++ b/src/app/[locale]/patterns/[slug]/page.tsx
@@ -34,13 +34,16 @@ export async function generateMetadata({
   const title = `${pattern.title} | AI Native Playbook`;
   const description = pattern.description;
 
+  const { locale } = await params;
+  const canonicalUrl = `${BASE_URL}/${locale}/patterns/${slug}`;
+
   return {
     title,
     description,
     openGraph: {
       title,
       description,
-      url: `${BASE_URL}/patterns/${slug}`,
+      url: canonicalUrl,
       type: "article",
       siteName: "AI Native Playbook",
       images: [{ url: `${BASE_URL}/opengraph-image`, width: 1200, height: 630, alt: title }],
@@ -51,7 +54,7 @@ export async function generateMetadata({
       description,
     },
     alternates: {
-      canonical: `${BASE_URL}/patterns/${slug}`,
+      canonical: canonicalUrl,
     },
   };
 }

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -11,7 +11,10 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-export function generateMetadata(): Metadata {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const canonicalUrl = `${BASE_URL}/${locale}/patterns`;
+
   return {
     title: "AI Architecture Patterns — Proven Business Frameworks Automated with AI | AI Native Playbook",
     description:
@@ -31,16 +34,16 @@ export function generateMetadata(): Metadata {
     openGraph: {
       title: "AI Architecture Patterns — Proven Business Frameworks Automated with AI | AI Native Playbook",
       description: "5 AI architecture patterns for business: Value Ladder, Mass Movement, Dream 100, Story Copy, Product Launch. Free to explore — runs on any AI.",
-      url: `${BASE_URL}/patterns`,
+      url: canonicalUrl,
       type: "website",
       images: [{ url: `${BASE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Architecture Patterns — AI Native Playbook" }],
     },
     alternates: {
-      canonical: `${BASE_URL}/patterns`,
+      canonical: canonicalUrl,
       languages: {
-        en: `${BASE_URL}/patterns`,
+        en: `${BASE_URL}/en/patterns`,
         ja: `${BASE_URL}/ja/patterns`,
-        "x-default": `${BASE_URL}/patterns`,
+        "x-default": `${BASE_URL}/en/patterns`,
       },
     },
   };

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -14,8 +14,7 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const canonicalUrl =
-    locale === "en" ? `${SITE_URL}/pricing` : `${SITE_URL}/${locale}/pricing`;
+  const canonicalUrl = `${SITE_URL}/${locale}/pricing`;
 
   return {
     title: "Pricing — AI Native Playbook Series",
@@ -31,9 +30,9 @@ export async function generateMetadata({
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${SITE_URL}/pricing`,
+        en: `${SITE_URL}/en/pricing`,
         ja: `${SITE_URL}/ja/pricing`,
-        "x-default": `${SITE_URL}/pricing`,
+        "x-default": `${SITE_URL}/en/pricing`,
       },
     },
     openGraph: {
@@ -146,8 +145,7 @@ export default async function PricingPage({
     ],
   };
 
-  const canonicalPricingUrl =
-    locale === "en" ? `${SITE_URL}/pricing` : `${SITE_URL}/${locale}/pricing`;
+  const canonicalPricingUrl = `${SITE_URL}/${locale}/pricing`;
 
   const offerCatalogJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -4,23 +4,28 @@ import { setRequestLocale } from "next-intl/server";
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
-export const metadata: Metadata = {
-  title: "Privacy Policy — AI Native Playbook Series",
-  description:
-    "Privacy Policy for AI Native Playbook Series by ai-architect. Learn how we collect, use, and protect your personal data in compliance with GDPR and international law.",
-  openGraph: {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const canonicalUrl = `${SITE_URL}/${locale}/privacy`;
+
+  return {
     title: "Privacy Policy — AI Native Playbook Series",
-    description: "Learn how we collect, use, and protect your personal data.",
-    images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
-  },
-  alternates: {
-    canonical: `${SITE_URL}/privacy`,
-  },
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+    description:
+      "Privacy Policy for AI Native Playbook Series by ai-architect. Learn how we collect, use, and protect your personal data in compliance with GDPR and international law.",
+    openGraph: {
+      title: "Privacy Policy — AI Native Playbook Series",
+      description: "Learn how we collect, use, and protect your personal data.",
+      images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
+    },
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
   en: { home: "Home", page: "Privacy Policy" },

--- a/src/app/[locale]/products/[slug]/quick-start/page.tsx
+++ b/src/app/[locale]/products/[slug]/quick-start/page.tsx
@@ -22,9 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const book = getBookBySlug(slug);
   if (!book) return {};
 
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/products/${slug}/quick-start`
-    : `${SITE_URL}/${locale}/products/${slug}/quick-start`;
+  const canonicalUrl = `${SITE_URL}/${locale}/products/${slug}/quick-start`;
 
   return {
     title: `Quick Start — ${book.title} | AI Native Playbook`,
@@ -251,9 +249,7 @@ export default async function QuickStartPage({ params }: Props) {
   const content = quickStartContent[slug];
   if (!content) notFound();
 
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/products/${slug}/quick-start`
-    : `${SITE_URL}/${locale}/products/${slug}/quick-start`;
+  const canonicalUrl = `${SITE_URL}/${locale}/products/${slug}/quick-start`;
 
   const howToJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/products/page.tsx
+++ b/src/app/[locale]/products/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
   const meta = productsMeta[locale] ?? productsMeta.en;
-  const canonicalUrl = locale === "en" ? `${siteUrl}/products` : `${siteUrl}/${locale}/products`;
+  const canonicalUrl = `${siteUrl}/${locale}/products`;
   const ogDescription = (meta as typeof productsMeta.en).ogDescription ?? meta.description;
 
   return {
@@ -51,9 +51,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        en: `${siteUrl}/products`,
+        en: `${siteUrl}/en/products`,
         ja: `${siteUrl}/ja/products`,
-        "x-default": `${siteUrl}/products`,
+        "x-default": `${siteUrl}/en/products`,
       },
     },
     openGraph: {
@@ -96,7 +96,7 @@ export default async function ProductsPage({ params }: { params: Promise<{ local
     return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
   }
 
-  const canonicalProductsUrl = locale === "en" ? `${siteUrl}/products` : `${siteUrl}/${locale}/products`;
+  const canonicalProductsUrl = `${siteUrl}/${locale}/products`;
 
   const jsonLd = [
     {

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -4,23 +4,28 @@ import { setRequestLocale } from "next-intl/server";
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
-export const metadata: Metadata = {
-  title: "Refund Policy — AI Native Playbook Series",
-  description:
-    "Refund policy for AI Native Playbook Series digital products. Full refund available within 14 days of purchase if the product has not been downloaded. Download available for 30 days from purchase.",
-  openGraph: {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const canonicalUrl = `${SITE_URL}/${locale}/refund`;
+
+  return {
     title: "Refund Policy — AI Native Playbook Series",
-    description: "Full refund within 14 days if not downloaded. Download available for 30 days.",
-    images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
-  },
-  alternates: {
-    canonical: `${SITE_URL}/refund`,
-  },
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+    description:
+      "Refund policy for AI Native Playbook Series digital products. Full refund available within 14 days of purchase if the product has not been downloaded. Download available for 30 days from purchase.",
+    openGraph: {
+      title: "Refund Policy — AI Native Playbook Series",
+      description: "Full refund within 14 days if not downloaded. Download available for 30 days.",
+      images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
+    },
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
   en: { home: "Home", page: "Refund Policy" },

--- a/src/app/[locale]/skill-guide/page.tsx
+++ b/src/app/[locale]/skill-guide/page.tsx
@@ -10,9 +10,7 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playboo
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/skill-guide`
-    : `${SITE_URL}/${locale}/skill-guide`;
+  const canonicalUrl = `${SITE_URL}/${locale}/skill-guide`;
 
   return {
     title: "AI Agent Skill Guide — How to Use Your .md Skill File | AI Native Playbook",
@@ -136,9 +134,7 @@ export default async function SkillGuidePage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const canonicalUrl = locale === "en"
-    ? `${SITE_URL}/skill-guide`
-    : `${SITE_URL}/${locale}/skill-guide`;
+  const canonicalUrl = `${SITE_URL}/${locale}/skill-guide`;
 
   const faqJsonLd = {
     "@context": "https://schema.org",

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -4,23 +4,28 @@ import { setRequestLocale } from "next-intl/server";
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
-export const metadata: Metadata = {
-  title: "Terms of Service — AI Native Playbook Series",
-  description:
-    "Terms of Service for AI Native Playbook Series by ai-architect. Digital product license, payment terms via Paddle, refund policy, and usage guidelines explained.",
-  openGraph: {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const canonicalUrl = `${SITE_URL}/${locale}/terms`;
+
+  return {
     title: "Terms of Service — AI Native Playbook Series",
-    description: "Digital product license, payment terms, refund policy, and usage guidelines.",
-    images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
-  },
-  alternates: {
-    canonical: `${SITE_URL}/terms`,
-  },
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+    description:
+      "Terms of Service for AI Native Playbook Series by ai-architect. Digital product license, payment terms via Paddle, refund policy, and usage guidelines explained.",
+    openGraph: {
+      title: "Terms of Service — AI Native Playbook Series",
+      description: "Digital product license, payment terms, refund policy, and usage guidelines.",
+      images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
+    },
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 const BREADCRUMB_LABELS: Record<string, { home: string; page: string }> = {
   en: { home: "Home", page: "Terms of Service" },


### PR DESCRIPTION
## Summary
- 17개 비블로그 페이지의 canonical URL에 locale prefix (`/en/`, `/ko/`, `/ja/`) 추가
- 기존: English locale에서 `/about` → 수정 후: `/en/about`
- `alternates.languages`의 `en` 및 `x-default` 항목도 `/en/` prefix 포함하도록 수정
- `products/[slug]/page.tsx`는 이미 `/en/` prefix가 있어 수정 불필요 (총 17파일 수정)

## 수정 파일 목록 (17파일)
| # | 파일 | 변경 내용 |
|---|------|-----------|
| 1 | `[locale]/about/page.tsx` | canonical + languages en/x-default |
| 2 | `[locale]/bundle/page.tsx` | canonical + languages en/x-default |
| 3 | `[locale]/faq/page.tsx` | canonical + canonicalFaqUrl + languages en/x-default |
| 4 | `[locale]/free-guide/page.tsx` | canonical (2곳) + languages en/x-default |
| 5 | `[locale]/free-guide/thank-you/page.tsx` | canonical |
| 6 | `[locale]/getting-started/page.tsx` | canonical (2곳) |
| 7 | `[locale]/layout.tsx` | pageUrl + languages en/x-default |
| 8 | `[locale]/page.tsx` | canonical + languages en/x-default |
| 9 | `[locale]/patterns/[slug]/page.tsx` | canonical (locale 파라미터 추가) |
| 10 | `[locale]/patterns/page.tsx` | static→generateMetadata 전환 + canonical + languages |
| 11 | `[locale]/pricing/page.tsx` | canonical + canonicalPricingUrl + languages en/x-default |
| 12 | `[locale]/privacy/page.tsx` | static→generateMetadata 전환 + canonical |
| 13 | `[locale]/products/[slug]/quick-start/page.tsx` | canonical (2곳) |
| 14 | `[locale]/products/page.tsx` | canonical + canonicalProductsUrl + languages en/x-default |
| 15 | `[locale]/refund/page.tsx` | static→generateMetadata 전환 + canonical |
| 16 | `[locale]/skill-guide/page.tsx` | canonical (2곳) |
| 17 | `[locale]/terms/page.tsx` | static→generateMetadata 전환 + canonical |

## Before / After
```
# Before (English locale)
canonical: https://ai-native-playbook.com/about
languages.en: https://ai-native-playbook.com/about

# After (English locale)
canonical: https://ai-native-playbook.com/en/about
languages.en: https://ai-native-playbook.com/en/about
```

## Test plan
- [x] `npm run build` 성공 확인
- [ ] 블로그/콘텐츠 파일 미포함 확인
- [ ] 변경 파일 수 ≤ 18 확인 (17파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed canonical URL and language alternate mappings across all pages to maintain consistent URL structure for all locales, including English. This improves search engine optimization and language routing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->