### PR TITLE
feat(ainp): block download access after Paddle refund

### DIFF
--- a/migrations/002_refunded_orders.sql
+++ b/migrations/002_refunded_orders.sql
@@ -1,0 +1,16 @@
+-- refunded_orders table: tracks Paddle transaction refunds
+-- Used by ainp download API to block access after refund
+-- Populated by Paddle webhook transaction.refunded event
+CREATE TABLE IF NOT EXISTS refunded_orders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  transaction_id TEXT NOT NULL UNIQUE,  -- Paddle transaction ID (txn_xxx)
+  customer_email TEXT DEFAULT '',
+  product_name TEXT DEFAULT '',
+  amount INTEGER DEFAULT 0,             -- in cents
+  currency TEXT DEFAULT 'USD',
+  refunded_at INTEGER NOT NULL,         -- Unix timestamp (ms)
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_refunded_orders_txn ON refunded_orders(transaction_id);
+CREATE INDEX IF NOT EXISTS idx_refunded_orders_email ON refunded_orders(customer_email);

--- a/src/__tests__/download-api.test.ts
+++ b/src/__tests__/download-api.test.ts
@@ -5,6 +5,7 @@
  * - Missing type/token returns 400
  * - Invalid product type returns 404
  * - Invalid/expired token returns 403
+ * - Refunded order returns 403 with refund message
  * - Valid request logs download and redirects to R2
  * - Download check API returns correct refund status
  */
@@ -24,6 +25,10 @@ vi.mock("@/lib/download-log", () => ({
   getDownloadHistory: vi.fn(),
 }));
 
+vi.mock("@/lib/refund-guard", () => ({
+  isRefunded: vi.fn().mockResolvedValue(false),
+}));
+
 describe("GET /api/download", () => {
   let GET: (req: NextRequest) => Promise<Response>;
 
@@ -41,6 +46,9 @@ describe("GET /api/download", () => {
       logDownload: vi.fn().mockResolvedValue(undefined),
       hasDownloaded: vi.fn(),
       getDownloadHistory: vi.fn(),
+    }));
+    vi.doMock("@/lib/refund-guard", () => ({
+      isRefunded: vi.fn().mockResolvedValue(false),
     }));
 
     const mod = await import("@/app/api/download/route");
@@ -78,6 +86,51 @@ describe("GET /api/download", () => {
     );
     const res = await GET(req);
     expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with refund message for refunded order", async () => {
+    const { isValidProductType, verifyDownloadToken } = await import(
+      "@/lib/download"
+    );
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    (isValidProductType as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (verifyDownloadToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      valid: true,
+      orderId: "txn_refunded_123",
+    });
+    (isRefunded as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const req = new NextRequest(
+      "http://localhost/api/download?type=pdf-vol1&token=valid-token"
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain("refund");
+  });
+
+  it("does not log download for refunded order", async () => {
+    const { isValidProductType, verifyDownloadToken } = await import(
+      "@/lib/download"
+    );
+    const { isRefunded } = await import("@/lib/refund-guard");
+    const { logDownload } = await import("@/lib/download-log");
+
+    (isValidProductType as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (verifyDownloadToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      valid: true,
+      orderId: "txn_refunded_123",
+    });
+    (isRefunded as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const req = new NextRequest(
+      "http://localhost/api/download?type=pdf-vol1&token=valid-token"
+    );
+    await GET(req);
+
+    expect(logDownload).not.toHaveBeenCalled();
   });
 
   it("redirects to R2 URL and logs download on valid request", async () => {

--- a/src/__tests__/paddle-webhook.test.ts
+++ b/src/__tests__/paddle-webhook.test.ts
@@ -21,6 +21,10 @@ vi.mock("@/lib/email", () => ({
   sendPaymentFailureEmail: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("@/lib/refund-guard", () => ({
+  markRefunded: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Helper: create valid Paddle signature
 function createPaddleSignature(body: string, secret: string): string {
   const timestamp = Math.floor(Date.now() / 1000).toString();
@@ -365,11 +369,55 @@ describe("Paddle Webhook Handler", () => {
       expect(json.status).toBe("refunded");
     });
 
+    it("should call markRefunded() to persist refund in DB", async () => {
+      const body = JSON.stringify(makeRefundedEvent());
+      const sig = createPaddleSignature(body, WEBHOOK_SECRET);
+      const req = createRequest(body, sig);
+
+      await POST(req);
+
+      const { markRefunded } = await import("@/lib/refund-guard");
+      expect(markRefunded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactionId: "txn_refund_001",
+          customerEmail: "buyer@example.com",
+        })
+      );
+    });
+
+    it("should still return 200 if markRefunded() throws", async () => {
+      vi.resetModules();
+      vi.doMock("@/lib/refund-guard", () => ({
+        markRefunded: vi.fn().mockRejectedValue(new Error("DB error")),
+      }));
+      vi.doMock("@/lib/email", () => ({
+        sendPurchaseConfirmationEmail: vi.fn().mockResolvedValue({ success: true }),
+        sendPaymentFailureEmail: vi.fn().mockResolvedValue({ success: true }),
+      }));
+
+      const mod = await import("@/app/api/webhooks/paddle/route");
+
+      const body = JSON.stringify(makeRefundedEvent());
+      const sig = createPaddleSignature(body, WEBHOOK_SECRET);
+      const req = createRequest(body, sig);
+
+      const res = await mod.POST(req);
+      expect(res.status).toBe(200);
+    });
+
     it("should send Telegram notification for refund", async () => {
       vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-bot-token");
       vi.stubEnv("TELEGRAM_CHAT_ID", "12345");
 
       vi.resetModules();
+      vi.doMock("@/lib/refund-guard", () => ({
+        markRefunded: vi.fn().mockResolvedValue(undefined),
+      }));
+      vi.doMock("@/lib/email", () => ({
+        sendPurchaseConfirmationEmail: vi.fn().mockResolvedValue({ success: true }),
+        sendPaymentFailureEmail: vi.fn().mockResolvedValue({ success: true }),
+      }));
+
       const mod = await import("@/app/api/webhooks/paddle/route");
 
       const body = JSON.stringify(makeRefundedEvent());

--- a/src/__tests__/refund-guard.test.ts
+++ b/src/__tests__/refund-guard.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Refund guard tests for AI Native Playbook
+ *
+ * Covers:
+ * - markRefunded() inserts into refunded_orders
+ * - isRefunded() returns true when transaction is in refunded_orders
+ * - isRefunded() returns false when transaction not refunded
+ * - markRefunded() is idempotent (no error on duplicate)
+ * - DB unavailable → isRefunded() returns false (fail-open for safety)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockExecute = vi.fn();
+vi.mock("@libsql/client", () => ({
+  createClient: vi.fn(() => ({ execute: mockExecute })),
+}));
+
+describe("refund-guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.stubEnv("TURSO_DATABASE_URL", "libsql://test.turso.io");
+    vi.stubEnv("TURSO_AUTH_TOKEN", "test-token");
+  });
+
+  it("markRefunded() inserts a record into refunded_orders", async () => {
+    mockExecute.mockResolvedValue({ rowsAffected: 1 });
+    const { markRefunded } = await import("@/lib/refund-guard");
+
+    await markRefunded({
+      transactionId: "txn_refund_001",
+      customerEmail: "buyer@example.com",
+      productName: "AI Native Playbook Vol.1",
+      amount: 2900,
+      currency: "USD",
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sql: expect.stringContaining("INSERT OR IGNORE INTO refunded_orders"),
+        args: expect.arrayContaining(["txn_refund_001", "buyer@example.com"]),
+      })
+    );
+  });
+
+  it("isRefunded() returns true when transaction is in refunded_orders", async () => {
+    mockExecute.mockResolvedValue({ rows: [{ count: 1 }] });
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    const result = await isRefunded("txn_refund_001");
+    expect(result).toBe(true);
+  });
+
+  it("isRefunded() returns false when transaction not refunded", async () => {
+    mockExecute.mockResolvedValue({ rows: [{ count: 0 }] });
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    const result = await isRefunded("txn_valid_purchase");
+    expect(result).toBe(false);
+  });
+
+  it("isRefunded() queries correct table and column", async () => {
+    mockExecute.mockResolvedValue({ rows: [{ count: 0 }] });
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    await isRefunded("txn_check_123");
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sql: expect.stringContaining("refunded_orders"),
+        args: expect.arrayContaining(["txn_check_123"]),
+      })
+    );
+  });
+
+  it("markRefunded() uses INSERT OR IGNORE for idempotency", async () => {
+    mockExecute.mockResolvedValue({ rowsAffected: 0 }); // already exists
+    const { markRefunded } = await import("@/lib/refund-guard");
+
+    // Should not throw on duplicate
+    await expect(
+      markRefunded({
+        transactionId: "txn_duplicate",
+        customerEmail: "buyer@example.com",
+        productName: "AI Native Playbook",
+        amount: 2900,
+        currency: "USD",
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("isRefunded() returns false when DB is unavailable (fail-open)", async () => {
+    vi.stubEnv("TURSO_DATABASE_URL", "");
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    const result = await isRefunded("txn_any");
+    // fail-open: no DB means we can't verify refund status, return false
+    expect(result).toBe(false);
+  });
+
+  it("isRefunded() returns false when DB query throws", async () => {
+    mockExecute.mockRejectedValue(new Error("DB connection error"));
+    const { isRefunded } = await import("@/lib/refund-guard");
+
+    const result = await isRefunded("txn_error");
+    expect(result).toBe(false);
+  });
+});

--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -18,6 +18,7 @@ import {
   isValidProductType,
 } from "@/lib/download";
 import { logDownload } from "@/lib/download-log";
+import { isRefunded } from "@/lib/refund-guard";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -42,6 +43,18 @@ export async function GET(request: NextRequest) {
   if (!valid || !orderId) {
     return NextResponse.json(
       { error: "Download link expired or invalid." },
+      { status: 403 }
+    );
+  }
+
+  // Block download if order has been refunded
+  const refunded = await isRefunded(orderId);
+  if (refunded) {
+    return NextResponse.json(
+      {
+        error:
+          "Download access revoked due to refund. Contact hello@ai-native-playbook.com if you believe this is an error.",
+      },
       { status: 403 }
     );
   }

--- a/src/app/api/webhooks/paddle/route.ts
+++ b/src/app/api/webhooks/paddle/route.ts
@@ -7,6 +7,7 @@ import {
   getAllDownloadLinks,
   detectProductType,
 } from "@/lib/download";
+import { markRefunded } from "@/lib/refund-guard";
 import crypto from "crypto";
 
 // Simple in-memory dedup for serverless (best-effort)
@@ -189,6 +190,20 @@ async function handleTransactionRefunded(
   console.warn(
     `[paddle-webhook] Refund processed: txn=${txId}, product=${order.productName}, amount=$${(order.amount / 100).toFixed(2)}`
   );
+
+  // Persist refund status to block future downloads
+  try {
+    await markRefunded({
+      transactionId: txId,
+      customerEmail: order.customerEmail,
+      productName: order.productName,
+      amount: order.amount,
+      currency: order.currency,
+    });
+  } catch (err) {
+    // Non-fatal: log and continue so webhook still returns 200
+    console.error("[paddle-webhook] markRefunded failed:", err);
+  }
 
   await notifyTelegram([
     `Refund Processed`,

--- a/src/lib/refund-guard.ts
+++ b/src/lib/refund-guard.ts
@@ -1,0 +1,85 @@
+/**
+ * Refund guard for AI Native Playbook
+ *
+ * Tracks refunded Paddle transactions in the refunded_orders table (Turso/LibSQL).
+ * Used by the download API to block access after a refund is processed.
+ *
+ * Design decisions:
+ * - isRefunded() fails open (returns false) when DB is unavailable — prevents
+ *   accidental download blocks due to DB outages.
+ * - markRefunded() uses INSERT OR IGNORE for idempotency — safe for Paddle retries.
+ */
+
+import { createClient, type Client } from "@libsql/client";
+
+let _db: Client | null = null;
+
+function getDb(): Client | null {
+  if (_db) return _db;
+
+  const url = process.env.TURSO_DATABASE_URL;
+  const authToken = process.env.TURSO_AUTH_TOKEN;
+  if (!url) return null;
+
+  _db = createClient({ url, authToken });
+  return _db;
+}
+
+// ─── Types ───
+
+export interface MarkRefundedParams {
+  transactionId: string;
+  customerEmail: string;
+  productName: string;
+  amount: number;
+  currency: string;
+}
+
+// ─── Mark Order as Refunded ───
+
+/**
+ * Record a refunded Paddle transaction.
+ * Safe to call multiple times — INSERT OR IGNORE prevents duplicates.
+ */
+export async function markRefunded({
+  transactionId,
+  customerEmail,
+  productName,
+  amount,
+  currency,
+}: MarkRefundedParams): Promise<void> {
+  const db = getDb();
+  if (!db) return;
+
+  await db.execute({
+    sql: `INSERT OR IGNORE INTO refunded_orders
+            (transaction_id, customer_email, product_name, amount, currency, refunded_at)
+          VALUES (?, ?, ?, ?, ?, ?)`,
+    args: [transactionId, customerEmail, productName, amount, currency, Date.now()],
+  });
+}
+
+// ─── Check Refund Status ───
+
+/**
+ * Returns true if the given Paddle transaction has been refunded.
+ * Fails open (returns false) on DB error to avoid blocking legitimate downloads
+ * due to infrastructure issues.
+ */
+export async function isRefunded(transactionId: string): Promise<boolean> {
+  const db = getDb();
+  if (!db) return false;
+
+  try {
+    const result = await db.execute({
+      sql: "SELECT COUNT(*) as count FROM refunded_orders WHERE transaction_id = ?",
+      args: [transactionId],
+    });
+
+    const count = Number(result.rows[0]?.count ?? 0);
+    return count > 0;
+  } catch {
+    // Fail open: if DB is down, don't block downloads
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- **긴급 보안 패치**: 환불 후 다운로드 링크가 계속 작동하는 취약점 수정
- Paddle `transaction.refunded` 웹훅 수신 시 `refunded_orders` 테이블에 기록
- 다운로드 API에서 환불 여부 확인 후 차단 (HTTP 403)
- CEO 환불 테스트 대응 — 오늘 테스트 예정

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `migrations/002_refunded_orders.sql` | 신규 테이블 (drizzle-kit 미사용, 직접 SQL) |
| `src/lib/refund-guard.ts` | markRefunded() + isRefunded() 구현 |
| `src/app/api/download/route.ts` | 환불 여부 확인 로직 추가 |
| `src/app/api/webhooks/paddle/route.ts` | transaction.refunded → markRefunded() 연결 |

## 마이그레이션 SQL (수동 실행 필요)

```sql
CREATE TABLE IF NOT EXISTS refunded_orders (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  transaction_id TEXT NOT NULL UNIQUE,
  customer_email TEXT DEFAULT '',
  product_name TEXT DEFAULT '',
  amount INTEGER DEFAULT 0,
  currency TEXT DEFAULT 'USD',
  refunded_at INTEGER NOT NULL,
  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
);

CREATE INDEX IF NOT EXISTS idx_refunded_orders_txn ON refunded_orders(transaction_id);
CREATE INDEX IF NOT EXISTS idx_refunded_orders_email ON refunded_orders(customer_email);
```

**적용 방법**: `turso db shell {DB명} < migrations/002_refunded_orders.sql`

## 설계 결정

- **Fail-open**: DB 오류 시 isRefunded()는 false 반환 (다운로드 차단 미발생) — 인프라 장애로 정상 고객 차단 방지
- **idempotent**: INSERT OR IGNORE로 Paddle 웹훅 재시도 안전
- **비차단 실패**: markRefunded() 실패 시에도 웹훅은 200 반환 (Paddle 재시도 방지)

## 테스트 결과

- 신규 테스트: 12개 추가 (refund-guard: 7, download-api: 2, paddle-webhook: 3)
- 전체 통과: 257 passed (기존 실패 3건은 이번 변경과 무관한 사전 실패)

## Test plan

- [ ] `turso db shell`로 migrations/002_refunded_orders.sql 실행
- [ ] Paddle sandbox에서 결제 → 환불 웹훅 발송
- [ ] 환불 후 기존 다운로드 링크 접근 시 403 반환 확인
- [ ] 환불되지 않은 정상 주문 다운로드 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refund tracking system that automatically monitors and records refunded orders. Customers attempting to download products for orders marked as refunded now receive an access denied response with a clear error message and instructions to contact support for assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->