### PR TITLE
fix(ainp): Brevo sender를 verified domain으로 변경 — 결제 후 이메일 미발송 수정

### DIFF
--- a/src/app/api/webhooks/paddle/route.ts
+++ b/src/app/api/webhooks/paddle/route.ts
@@ -141,19 +141,30 @@ async function handleTransactionCompleted(
   // PayPal payments often have billing_details=null and customer={}
   // so we fall back to the Paddle Transactions API with ?include=customer
   if (!order.customerEmail || !order.productName || order.productName === "AI Native Playbook") {
+    console.log(
+      `[paddle-webhook] Enrichment needed: txn=${txId}, email="${order.customerEmail || "(empty)"}", product="${order.productName || "(empty)"}". Calling Paddle API...`
+    );
     const enriched = await fetchPaddleTransactionDetails(txId);
     if (enriched) {
+      console.log(
+        `[paddle-webhook] Paddle API enrichment result: email="${enriched.customerEmail || "(empty)"}", name="${enriched.customerName || "(empty)"}", product="${enriched.productName || "(empty)"}"`
+      );
       if (!order.customerEmail && enriched.customerEmail) {
         order.customerEmail = enriched.customerEmail;
         console.log(`[paddle-webhook] Enriched email from API: ${enriched.customerEmail}`);
       }
       if (!order.customerName && enriched.customerName) {
         order.customerName = enriched.customerName;
+        console.log(`[paddle-webhook] Enriched name from API: ${enriched.customerName}`);
       }
       if (enriched.productName && order.productName === "AI Native Playbook") {
         order.productName = enriched.productName;
         console.log(`[paddle-webhook] Enriched product from API: ${enriched.productName}`);
       }
+    } else {
+      console.warn(
+        `[paddle-webhook] Paddle API enrichment returned null for txn=${txId}. Customer email may still be empty.`
+      );
     }
   }
 
@@ -173,19 +184,22 @@ async function handleTransactionCompleted(
     success: false,
     error: "not attempted",
   };
+  console.log(
+    `[paddle-webhook] Sending Brevo email: txn=${txId}, to="${order.customerEmail || "(empty)"}", sender=contact@apppro.kr, downloadLinks=${Object.keys(downloadLinks).join(",")}`
+  );
   try {
     emailResult = await sendPurchaseConfirmationEmail(order, txId, downloadLinks);
     if (!emailResult.success) {
       console.error(
-        `[paddle-webhook] Email send returned failure: txn=${txId}, error=${emailResult.error}`
+        `[paddle-webhook] Brevo API returned failure: txn=${txId}, error="${emailResult.error}"`
       );
     } else {
       console.log(
-        `[paddle-webhook] Email sent successfully: txn=${txId}, messageId=${emailResult.messageId}`
+        `[paddle-webhook] Brevo email sent successfully: txn=${txId}, messageId=${emailResult.messageId}`
       );
     }
   } catch (emailErr) {
-    console.error("[paddle-webhook] Email send threw exception:", emailErr);
+    console.error("[paddle-webhook] Brevo send threw exception:", emailErr);
     emailResult = {
       success: false,
       error: emailErr instanceof Error ? emailErr.message : String(emailErr),
@@ -347,8 +361,11 @@ function extractCustomerEmail(tx: Record<string, unknown>): string {
   if (!email) {
     console.warn(
       `[paddle-webhook] Could not extract customer email. Available keys: ${Object.keys(tx).join(", ")}. ` +
-      `billing_details=${JSON.stringify(tx.billing_details)}, customer=${JSON.stringify(tx.customer)}`
+      `billing_details=${JSON.stringify(tx.billing_details)}, customer=${JSON.stringify(tx.customer)}, ` +
+      `checkout=${JSON.stringify(tx.checkout)}, customer_email=${JSON.stringify(tx.customer_email)}`
     );
+  } else {
+    console.log(`[paddle-webhook] Customer email extracted: "${email}"`);
   }
   return email;
 }
@@ -494,7 +511,12 @@ async function fetchPaddleTransactionDetails(
 async function notifyTelegram(lines: string[]): Promise<void> {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   const chatId = process.env.TELEGRAM_CHAT_ID;
-  if (!botToken || !chatId) return;
+  if (!botToken || !chatId) {
+    console.warn(
+      `[paddle-webhook] Telegram notification skipped: ${!botToken ? "TELEGRAM_BOT_TOKEN" : ""} ${!chatId ? "TELEGRAM_CHAT_ID" : ""} not configured in environment variables`
+    );
+    return;
+  }
 
   const message = lines.join("\n");
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -47,7 +47,7 @@ export async function sendPurchaseConfirmationEmail(
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-native-playbook.com",
+        email: "contact@apppro.kr",
       },
       to: [{ email: order.customerEmail, name: order.customerName || undefined }],
       subject: `Your ${order.productName} is ready to download`,
@@ -212,7 +212,7 @@ export async function sendPaymentFailureEmail(
     body: JSON.stringify({
       sender: {
         name: "AI Native Playbook Series",
-        email: "hello@ai-native-playbook.com",
+        email: "contact@apppro.kr",
       },
       to: [{ email: customerEmail, name: customerName || undefined }],
       subject: `Action needed: Payment issue for ${productName}`,


### PR DESCRIPTION
## Summary

- **Root cause**: `hello@ai-native-playbook.com`이 Brevo에 미인증 도메인이라 이메일 발송 실패
- `src/lib/email.ts`: sender email을 `contact@apppro.kr` (Brevo 인증 완료 도메인)으로 변경 — `sendPurchaseConfirmationEmail` 및 `sendPaymentFailureEmail` 두 함수 모두 적용
- `src/app/api/webhooks/paddle/route.ts`: Brevo 호출 전후 상세 로그, Paddle API 보강 로그, Telegram 환경변수 미설정 경고 로그 추가

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `src/lib/email.ts` (line 50) | `hello@ai-native-playbook.com` → `contact@apppro.kr` |
| `src/lib/email.ts` (line 215) | 동일 (sendPaymentFailureEmail) |
| `src/app/api/webhooks/paddle/route.ts` | fetchPaddleTransactionDetails 호출 전후 로그, Brevo API 결과 상세 로그, extractCustomerEmail 성공/실패 로그, Telegram warning 로그 |

## Verified Brevo Senders

- `contact@apppro.kr` — active, domain verified

## Test plan

- [ ] `npm run build` 통과 확인 (완료)
- [ ] 스테이징 배포 후 Paddle sandbox 결제 → Vercel 함수 로그에서 `Brevo email sent successfully` 확인
- [ ] VP batch merge 대기

## Notes

- PR 머지는 VP가 batch로 처리 (직접 머지 금지)
- main → staging → production 브랜치 순서 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)