### PR TITLE
fix(seo): optimize blog titles to under 60 chars

### DIFF
--- a/content/blog/ai-native-product-builder-playbook.md
+++ b/content/blog/ai-native-product-builder-playbook.md
@@ -1,5 +1,5 @@
 ---
-title: "The AI-Native Product Builder's Playbook: Ship Your First Product in 30 Days"
+title: "AI-Native Product Builder's Playbook: Ship in 30 Days"
 description: "A step-by-step framework to go from idea to paying customers in 30 days — no team, no funding, just you and AI tools."
 date: "2026-03-22"
 author: "AI Native Playbook"

--- a/content/blog/ai-native-vs-traditional-saas-2026.md
+++ b/content/blog/ai-native-vs-traditional-saas-2026.md
@@ -1,5 +1,5 @@
 ---
-title: "AI-Native vs Traditional SaaS: A Data-Driven Comparison for 2026"
+title: "AI-Native vs Traditional SaaS: 2026 Data Comparison"
 description: "A comprehensive data-driven analysis comparing AI-native and traditional SaaS across development speed, team structure, pricing, and growth patterns in 2026."
 date: "2026-03-21"
 author: "AI Native Playbook"

--- a/content/blog/from-burned-out-pm-to-12k-ai-native.md
+++ b/content/blog/from-burned-out-pm-to-12k-ai-native.md
@@ -1,5 +1,5 @@
 ---
-title: "From Burned-Out PM to $12K/mo: One Builder's AI-Native Journey"
+title: "From Burned-Out PM to $12K/mo: An AI-Native Journey"
 description: "How a non-technical product manager built an AI-native SaaS earning $12K/month in 8 months — with no coding background, no funding, and no team."
 date: "2026-03-22"
 author: "AI Native Playbook"


### PR DESCRIPTION
## Summary
- SEO 감사에서 발견된 60자 초과 블로그 title 3건 최적화
- Google SERP 말줄임 방지로 CTR 개선 기대

## Changes (before → after)

| File | Before (chars) | After (chars) |
|------|---------------|--------------|
| ai-native-product-builder-playbook.md | The AI-Native Product Builder's Playbook: Ship Your First Product in 30 Days (76) | AI-Native Product Builder's Playbook: Ship in 30 Days (53) |
| ai-native-vs-traditional-saas-2026.md | AI-Native vs Traditional SaaS: A Data-Driven Comparison for 2026 (64) | AI-Native vs Traditional SaaS: 2026 Data Comparison (51) |
| from-burned-out-pm-to-12k-ai-native.md | From Burned-Out PM to $12K/mo: One Builder's AI-Native Journey (62) | From Burned-Out PM to $12K/mo: An AI-Native Journey (51) |

## Test plan
- [ ] Verify titles render correctly on blog listing page
- [ ] Verify individual post pages show updated titles
- [ ] Check meta title tags in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)