### PR TITLE
fix(fulfillment): email retry + failure alerting

### DIFF
--- a/src/app/api/delivery/fulfill/route.ts
+++ b/src/app/api/delivery/fulfill/route.ts
@@ -138,15 +138,25 @@ export async function POST(request: NextRequest) {
     siteUrl
   );
 
-  // Send email
+  // Send email (with retry — max 3 attempts)
   const emailResult = await sendPurchaseConfirmationEmail(
     order,
     transactionId,
-    downloadLinks
+    downloadLinks,
+    { maxRetries: 3 }
   );
 
   console.log(
     `[delivery/fulfill] Manual fulfillment: txn=${transactionId}, email=${customerEmail}, product=${productName}, emailSuccess=${emailResult.success}`
+  );
+
+  // Notify CEO via Telegram about manual fulfillment result
+  await notifyTelegramFulfillment(
+    transactionId,
+    customerEmail,
+    productName,
+    emailResult.success,
+    emailResult.error
   );
 
   return NextResponse.json({
@@ -159,6 +169,42 @@ export async function POST(request: NextRequest) {
     emailResult,
     thankYouUrl: `${siteUrl}/thank-you?token=${downloadToken}&type=${productType}&product=${encodeURIComponent(productName)}`,
   });
+}
+
+/**
+ * Notify CEO via Telegram about manual fulfillment result.
+ * Fails silently — fulfillment response is returned regardless.
+ */
+async function notifyTelegramFulfillment(
+  transactionId: string,
+  customerEmail: string,
+  productName: string,
+  emailSuccess: boolean,
+  emailError?: string
+): Promise<void> {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!botToken || !chatId) return;
+
+  const lines = [
+    `🔧 Manual Fulfillment ${emailSuccess ? "✅" : "❌"}`,
+    `Transaction: ${transactionId}`,
+    `Customer: ${customerEmail}`,
+    `Product: ${productName}`,
+    emailSuccess
+      ? `Email: ✅ Sent successfully`
+      : `Email: ❌ FAILED - ${emailError}`,
+  ];
+
+  try {
+    await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: lines.join("\n") }),
+    });
+  } catch (err) {
+    console.error("[delivery/fulfill] Telegram notification failed:", err);
+  }
 }
 
 // ─── Helpers ───

--- a/src/app/api/webhooks/paddle/route.ts
+++ b/src/app/api/webhooks/paddle/route.ts
@@ -179,7 +179,7 @@ async function handleTransactionCompleted(
     `[paddle-webhook] transaction.completed: txn=${txId}, email=${order.customerEmail}, product=${order.productName}, amount=${order.amount}, links=${Object.keys(downloadLinks).length}`
   );
 
-  // Send confirmation email with download links
+  // Send confirmation email with download links (with retry — max 3 attempts)
   let emailResult: { success: boolean; error?: string; messageId?: string } = {
     success: false,
     error: "not attempted",
@@ -188,10 +188,10 @@ async function handleTransactionCompleted(
     `[paddle-webhook] Sending confirmation email via Resend: txn=${txId}, to="${order.customerEmail || "(empty)"}", sender=noreply@apppro.kr, downloadLinks=${Object.keys(downloadLinks).join(",")}`
   );
   try {
-    emailResult = await sendPurchaseConfirmationEmail(order, txId, downloadLinks);
+    emailResult = await sendPurchaseConfirmationEmail(order, txId, downloadLinks, { maxRetries: 3 });
     if (!emailResult.success) {
       console.error(
-        `[paddle-webhook] Email send failed: txn=${txId}, error="${emailResult.error}"`
+        `[paddle-webhook] Email send failed after retries: txn=${txId}, error="${emailResult.error}"`
       );
     } else {
       console.log(
@@ -207,19 +207,36 @@ async function handleTransactionCompleted(
   }
 
   // Notify CEO via Telegram
-  await notifyTelegram([
-    `New Purchase!`,
+  const siteUrlForNotify =
+    (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
+  const telegramLines = [
+    `🛒 New Purchase!`,
     `Product: ${order.productName}`,
     `Amount: $${(order.amount / 100).toFixed(2)} ${order.currency}`,
     `Customer: ${order.customerEmail}`,
     `Transaction: ${txId}`,
-    `Email: ${emailResult.success ? "Sent" : `FAILED - ${emailResult.error}`}`,
-  ]);
+    `Email: ${emailResult.success ? `✅ Sent (${emailResult.messageId})` : `❌ FAILED - ${emailResult.error}`}`,
+  ];
+
+  // If email failed, add manual fulfillment instructions
+  if (!emailResult.success) {
+    telegramLines.push(
+      ``,
+      `⚠️ MANUAL FULFILLMENT NEEDED`,
+      `Run: curl -X POST ${siteUrlForNotify}/api/delivery/fulfill \\`,
+      `  -H "Authorization: Bearer $PADDLE_API_KEY" \\`,
+      `  -H "Content-Type: application/json" \\`,
+      `  -d '{"transactionId":"${txId}"}'`
+    );
+  }
+
+  await notifyTelegram(telegramLines);
 
   return NextResponse.json({
     received: true,
     orderId: order.id,
     status: "completed",
+    emailSent: emailResult.success,
   });
 }
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -25,7 +25,8 @@ export interface EmailSendResult {
 export async function sendPurchaseConfirmationEmail(
   order: Order,
   transactionId: string,
-  downloadLinks?: Record<string, string>
+  downloadLinks?: Record<string, string>,
+  options?: { maxRetries?: number }
 ): Promise<EmailSendResult> {
   const resendKey = process.env.RESEND_API_KEY;
   if (!resendKey) {
@@ -41,30 +42,63 @@ export async function sendPurchaseConfirmationEmail(
 
   const htmlContent = buildConfirmationEmailHtml(order, transactionId, siteUrl, downloadLinks);
 
-  const res = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${resendKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: "AI Native Playbook <noreply@apppro.kr>",
-      to: [order.customerEmail],
-      subject: `Your ${order.productName} is ready to download`,
-      html: htmlContent,
-    }),
-  });
+  const maxRetries = options?.maxRetries ?? 3;
+  let lastError = "";
 
-  if (!res.ok) {
-    const errText = await res.text();
-    return {
-      success: false,
-      error: `Resend API error: ${res.status} ${errText}`,
-    };
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${resendKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: "AI Native Playbook <noreply@apppro.kr>",
+          to: [order.customerEmail],
+          subject: `Your ${order.productName} is ready to download`,
+          html: htmlContent,
+        }),
+      });
+
+      if (res.ok) {
+        const data = await res.json() as { id?: string };
+        if (attempt > 1) {
+          console.log(
+            `[email] Succeeded on attempt ${attempt}/${maxRetries}: txn=${transactionId}`
+          );
+        }
+        return { success: true, messageId: data.id };
+      }
+
+      const errText = await res.text();
+      lastError = `Resend API error: ${res.status} ${errText}`;
+
+      // Don't retry on 4xx client errors (except 429 rate limit)
+      if (res.status >= 400 && res.status < 500 && res.status !== 429) {
+        console.error(
+          `[email] Non-retryable error (${res.status}), attempt ${attempt}/${maxRetries}: txn=${transactionId}, error=${lastError}`
+        );
+        break;
+      }
+
+      console.warn(
+        `[email] Attempt ${attempt}/${maxRetries} failed: txn=${transactionId}, error=${lastError}`
+      );
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[email] Attempt ${attempt}/${maxRetries} threw: txn=${transactionId}, error=${lastError}`
+      );
+    }
+
+    // Exponential backoff: 1s, 2s before retries (skip delay on last attempt)
+    if (attempt < maxRetries) {
+      await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
   }
 
-  const data = await res.json() as { id?: string };
-  return { success: true, messageId: data.id };
+  return { success: false, error: lastError };
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Email retry logic**: `sendPurchaseConfirmationEmail` now retries up to 3 times with exponential backoff (1s, 2s). Non-retryable 4xx client errors (except 429 rate limit) stop early to avoid wasting attempts.
- **Webhook failure alerting**: When email delivery fails after all retries, the Telegram notification to CEO now includes a ready-to-use `curl` command for manual fulfillment via `/api/delivery/fulfill`.
- **Manual fulfill observability**: The `/api/delivery/fulfill` endpoint now sends a Telegram notification on completion (success or failure), so CEO gets visibility into manual recovery actions.

## Files changed (3 only)
- `src/lib/email.ts` — retry wrapper with backoff
- `src/app/api/webhooks/paddle/route.ts` — enhanced failure Telegram alert
- `src/app/api/delivery/fulfill/route.ts` — Telegram notification on manual fulfillment

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Test webhook with sandbox transaction — email should send on first attempt
- [ ] Simulate Resend API failure — verify retry logs appear and Telegram alert includes manual fulfillment command
- [ ] Test `/api/delivery/fulfill` — verify Telegram notification sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)