### PR TITLE
feat: AI Native Score assessment at /score

### DIFF
--- a/src/app/[locale]/score/layout.tsx
+++ b/src/app/[locale]/score/layout.tsx
@@ -2,18 +2,53 @@ import type { Metadata } from "next";
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://ai-native-playbook.com").trim();
 
+type Tier = "beginner" | "adopter" | "native";
+
+const tierLabels: Record<Tier, string> = {
+  beginner: "Beginner",
+  adopter: "Adopter",
+  native: "Native",
+};
+
+function isValidTier(t: string | undefined): t is Tier {
+  return t === "beginner" || t === "adopter" || t === "native";
+}
+
 export async function generateMetadata({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ s?: string; t?: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  const sp = await searchParams;
   const canonicalUrl = `${SITE_URL}/${locale}/score`;
 
+  // Check for shared score params
+  const rawScore = sp?.s ? parseInt(sp.s, 10) : null;
+  const score = rawScore !== null && !isNaN(rawScore) ? Math.max(0, Math.min(30, rawScore)) : null;
+  const tier = isValidTier(sp?.t) ? sp.t : null;
+
+  const hasScore = score !== null;
+
+  // Dynamic title/description for shared results
+  const title = hasScore
+    ? `I scored ${score}/30 on the AI Native Score${tier ? ` — ${tierLabels[tier]}` : ""}`
+    : "AI Native Score — How AI-Ready Is Your Business?";
+
+  const description = hasScore
+    ? `My AI readiness score is ${score}/30${tier ? ` (${tierLabels[tier]})` : ""}. How AI-ready is YOUR business? Take the free 2-minute assessment.`
+    : "Take the free 2-minute AI readiness assessment. 10 questions to measure how AI-native your business really is. Get your score and personalized recommendations.";
+
+  // Dynamic OG image: use API route with score param when available
+  const ogImageUrl = hasScore
+    ? `${SITE_URL}/api/og/score?s=${score}`
+    : `${SITE_URL}/${locale}/score/opengraph-image`;
+
   return {
-    title: "AI Native Score — How AI-Ready Is Your Business?",
-    description:
-      "Take the free 2-minute AI readiness assessment. 10 questions to measure how AI-native your business really is. Get your score and personalized recommendations.",
+    title,
+    description,
     keywords: [
       "AI readiness assessment",
       "AI native score",
@@ -35,28 +70,28 @@ export async function generateMetadata({
       },
     },
     openGraph: {
-      title: "AI Native Score — How AI-Ready Is Your Business?",
-      description:
-        "Free 2-minute assessment: 10 questions to measure your business AI readiness. Get your score, tier, and personalized playbook recommendations.",
+      title,
+      description,
       type: "website",
       url: canonicalUrl,
       siteName: "AI Native Playbook",
       locale: locale === "ja" ? "ja_JP" : "en_US",
       images: [
         {
-          url: `${SITE_URL}/opengraph-image`,
+          url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: "AI Native Score — AI Readiness Assessment",
+          alt: hasScore
+            ? `AI Native Score: ${score}/30`
+            : "AI Native Score — AI Readiness Assessment",
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: "AI Native Score — How AI-Ready Is Your Business?",
-      description:
-        "Free 2-minute assessment: 10 questions to discover your AI readiness level. Take the quiz now.",
-      images: [`${SITE_URL}/opengraph-image`],
+      title,
+      description,
+      images: [ogImageUrl],
     },
     robots: {
       index: true,

--- a/src/app/[locale]/score/opengraph-image.tsx
+++ b/src/app/[locale]/score/opengraph-image.tsx
@@ -1,0 +1,185 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "AI Native Score — AI Readiness Assessment";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+type Tier = "beginner" | "adopter" | "native";
+
+interface TierStyle {
+  label: string;
+  color: string;
+  bgAccent: string;
+  borderAccent: string;
+}
+
+const tierStyles: Record<Tier, TierStyle> = {
+  beginner: {
+    label: "Beginner",
+    color: "#fb923c",
+    bgAccent: "rgba(251,146,60,0.12)",
+    borderAccent: "rgba(251,146,60,0.35)",
+  },
+  adopter: {
+    label: "Adopter",
+    color: "#60a5fa",
+    bgAccent: "rgba(96,165,250,0.12)",
+    borderAccent: "rgba(96,165,250,0.35)",
+  },
+  native: {
+    label: "Native",
+    color: "#34d399",
+    bgAccent: "rgba(52,211,153,0.12)",
+    borderAccent: "rgba(52,211,153,0.35)",
+  },
+};
+
+function getTier(score: number): Tier {
+  if (score <= 10) return "beginner";
+  if (score <= 20) return "adopter";
+  return "native";
+}
+
+export default async function Image({
+  params,
+}: {
+  params: { locale: string };
+  searchParams?: { s?: string; t?: string };
+}) {
+  // Note: Next.js opengraph-image.tsx does NOT receive searchParams.
+  // Dynamic OG with score requires a route handler (see /api/og/score).
+  // This file generates the default OG image for /score without personalized score.
+
+  const locale = (params?.locale as string) || "en";
+  const isJa = locale === "ja";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background:
+            "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px",
+          position: "relative",
+        }}
+      >
+        {/* Gold accent bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "4px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+
+        {/* Badge */}
+        <div
+          style={{
+            background: "rgba(226,183,20,0.1)",
+            border: "1px solid rgba(226,183,20,0.3)",
+            color: "#e2b714",
+            fontSize: "14px",
+            fontWeight: "700",
+            padding: "6px 20px",
+            borderRadius: "100px",
+            marginBottom: "32px",
+            letterSpacing: "2px",
+            textTransform: "uppercase",
+          }}
+        >
+          FREE AI READINESS ASSESSMENT
+        </div>
+
+        {/* Score circle placeholder */}
+        <div
+          style={{
+            width: "160px",
+            height: "160px",
+            borderRadius: "50%",
+            border: "6px solid rgba(226,183,20,0.3)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            marginBottom: "32px",
+            background: "rgba(226,183,20,0.05)",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "48px",
+              fontWeight: "800",
+              color: "#e2b714",
+            }}
+          >
+            ?
+          </div>
+          <div
+            style={{
+              fontSize: "14px",
+              color: "#94a3b8",
+            }}
+          >
+            / 30
+          </div>
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: "48px",
+            fontWeight: "800",
+            color: "#f1f5f9",
+            textAlign: "center",
+            lineHeight: 1.15,
+            marginBottom: "16px",
+          }}
+        >
+          AI Native Score
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: "22px",
+            fontWeight: "400",
+            color: "#94a3b8",
+            textAlign: "center",
+            maxWidth: "700px",
+            lineHeight: 1.4,
+          }}
+        >
+          {isJa
+            ? "あなたのビジネスのAI準備度を2分で診断"
+            : "How AI-ready is your business? Take the 2-minute quiz."}
+        </div>
+
+        {/* Branding */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "16px",
+            color: "#e2b714",
+            fontWeight: "600",
+          }}
+        >
+          AI Native Playbook
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/[locale]/score/page.tsx
+++ b/src/app/[locale]/score/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, Suspense } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 
 /* ──────────────────────────── Data ──────────────────────────── */
 
@@ -354,15 +354,75 @@ function EmailCapture() {
 
 /* ──────────────────────────── Main Page ──────────────────────────── */
 
-export default function ScorePage() {
+function SharedPreview({
+  sharedScore,
+  sharedTier,
+  onStart,
+}: {
+  sharedScore: number;
+  sharedTier: Tier;
+  onStart: () => void;
+}) {
+  const info = tiers[sharedTier];
+  return (
+    <div className="min-h-screen pt-24 pb-20">
+      <div className="max-w-2xl mx-auto px-4 text-center">
+        <span className="inline-block bg-gold/10 border border-gold/20 text-gold text-xs font-semibold px-4 py-1.5 rounded-full tracking-wide uppercase mb-6">
+          Shared Result
+        </span>
+        <p className="text-text-secondary mb-6">
+          Someone scored:
+        </p>
+
+        <ScoreRing score={sharedScore} max={30} />
+
+        <h1 className={`text-3xl md:text-4xl font-bold mb-3 ${info.color}`}>
+          {info.label}
+        </h1>
+        <p className="text-lg font-semibold text-text-primary mb-3">
+          {info.headline}
+        </p>
+        <p className="text-text-secondary leading-relaxed max-w-lg mx-auto mb-10">
+          {info.description}
+        </p>
+
+        <button
+          onClick={onStart}
+          className="inline-block px-8 py-4 bg-gold text-navy-dark font-bold rounded-xl text-lg hover:bg-gold-light transition-colors"
+        >
+          Take the Assessment Yourself &rarr;
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ScorePageInner() {
   const params = useParams();
+  const searchParams = useSearchParams();
   const locale = (params?.locale as string) || "en";
+
+  // Check for shared score in URL params
+  const sharedScoreRaw = searchParams.get("s");
+  const sharedTierRaw = searchParams.get("t");
+  const sharedScoreNum = sharedScoreRaw ? parseInt(sharedScoreRaw, 10) : null;
+  const validSharedScore =
+    sharedScoreNum !== null && !isNaN(sharedScoreNum)
+      ? Math.max(0, Math.min(30, sharedScoreNum))
+      : null;
+  const validSharedTier: Tier | null =
+    sharedTierRaw === "beginner" || sharedTierRaw === "adopter" || sharedTierRaw === "native"
+      ? sharedTierRaw
+      : validSharedScore !== null
+        ? getTier(validSharedScore)
+        : null;
 
   const [currentQ, setCurrentQ] = useState(0);
   const [answers, setAnswers] = useState<(number | null)[]>(
     Array(questions.length).fill(null)
   );
   const [showResult, setShowResult] = useState(false);
+  const [dismissedPreview, setDismissedPreview] = useState(false);
 
   const score = answers.reduce<number>((sum, a) => sum + (a ?? 0), 0);
   const tier = getTier(score);
@@ -397,7 +457,20 @@ export default function ScorePage() {
   };
 
   const siteUrl = "https://ai-native-playbook.com";
-  const shareUrl = `${siteUrl}/${locale}/score`;
+  const shareUrl = showResult
+    ? `${siteUrl}/${locale}/score?s=${score}&t=${tier}`
+    : `${siteUrl}/${locale}/score`;
+
+  /* ── Shared Preview View ── */
+  if (validSharedScore !== null && validSharedTier !== null && !dismissedPreview && !showResult) {
+    return (
+      <SharedPreview
+        sharedScore={validSharedScore}
+        sharedTier={validSharedTier}
+        onStart={() => setDismissedPreview(true)}
+      />
+    );
+  }
 
   /* ── Result View ── */
   if (showResult) {
@@ -541,5 +614,19 @@ export default function ScorePage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function ScorePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen pt-24 pb-20 flex items-center justify-center">
+          <div className="text-text-secondary">Loading...</div>
+        </div>
+      }
+    >
+      <ScorePageInner />
+    </Suspense>
   );
 }

--- a/src/app/api/og/score/route.tsx
+++ b/src/app/api/og/score/route.tsx
@@ -1,0 +1,296 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+type Tier = "beginner" | "adopter" | "native";
+
+const tierMeta: Record<
+  Tier,
+  { label: string; color: string; ring: string; bg: string }
+> = {
+  beginner: {
+    label: "Beginner",
+    color: "#fb923c",
+    ring: "#fb923c",
+    bg: "rgba(251,146,60,0.12)",
+  },
+  adopter: {
+    label: "Adopter",
+    color: "#60a5fa",
+    ring: "#60a5fa",
+    bg: "rgba(96,165,250,0.12)",
+  },
+  native: {
+    label: "Native",
+    color: "#34d399",
+    ring: "#34d399",
+    bg: "rgba(52,211,153,0.12)",
+  },
+};
+
+function getTier(score: number): Tier {
+  if (score <= 10) return "beginner";
+  if (score <= 20) return "adopter";
+  return "native";
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const rawScore = parseInt(searchParams.get("s") || "", 10);
+  const score = isNaN(rawScore) ? null : Math.max(0, Math.min(30, rawScore));
+
+  // If no valid score, show generic image
+  if (score === null) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            background:
+              "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: "sans-serif",
+            padding: "60px",
+            position: "relative",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              height: "4px",
+              background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+            }}
+          />
+          <div
+            style={{
+              background: "rgba(226,183,20,0.1)",
+              border: "1px solid rgba(226,183,20,0.3)",
+              color: "#e2b714",
+              fontSize: "14px",
+              fontWeight: "700",
+              padding: "6px 20px",
+              borderRadius: "100px",
+              marginBottom: "32px",
+              letterSpacing: "2px",
+              textTransform: "uppercase",
+            }}
+          >
+            FREE AI READINESS ASSESSMENT
+          </div>
+          <div
+            style={{
+              fontSize: "52px",
+              fontWeight: "800",
+              color: "#f1f5f9",
+              textAlign: "center",
+              lineHeight: 1.15,
+              marginBottom: "16px",
+            }}
+          >
+            AI Native Score
+          </div>
+          <div
+            style={{
+              fontSize: "24px",
+              color: "#94a3b8",
+              textAlign: "center",
+            }}
+          >
+            How AI-ready is your business? Take the 2-minute quiz.
+          </div>
+          <div
+            style={{
+              position: "absolute",
+              bottom: "30px",
+              right: "40px",
+              fontSize: "16px",
+              color: "#e2b714",
+              fontWeight: "600",
+            }}
+          >
+            AI Native Playbook
+          </div>
+        </div>
+      ),
+      { width: 1200, height: 630 },
+    );
+  }
+
+  // Personalized score image
+  const tier = getTier(score);
+  const meta = tierMeta[tier];
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background:
+            "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "60px 80px",
+          position: "relative",
+          gap: "80px",
+        }}
+      >
+        {/* Gold accent bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "4px",
+            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+          }}
+        />
+
+        {/* Left: Score circle */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "20px",
+          }}
+        >
+          <div
+            style={{
+              width: "220px",
+              height: "220px",
+              borderRadius: "50%",
+              border: `8px solid ${meta.ring}`,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              background: meta.bg,
+            }}
+          >
+            <div
+              style={{
+                fontSize: "80px",
+                fontWeight: "800",
+                color: meta.color,
+                lineHeight: 1,
+              }}
+            >
+              {score}
+            </div>
+            <div
+              style={{
+                fontSize: "20px",
+                color: "#94a3b8",
+                marginTop: "4px",
+              }}
+            >
+              / 30
+            </div>
+          </div>
+
+          {/* Tier badge */}
+          <div
+            style={{
+              background: meta.bg,
+              border: `1px solid ${meta.ring}`,
+              color: meta.color,
+              fontSize: "18px",
+              fontWeight: "700",
+              padding: "8px 24px",
+              borderRadius: "100px",
+              letterSpacing: "1px",
+              textTransform: "uppercase",
+            }}
+          >
+            {meta.label}
+          </div>
+        </div>
+
+        {/* Right: Text */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            maxWidth: "520px",
+          }}
+        >
+          <div
+            style={{
+              background: "rgba(226,183,20,0.1)",
+              border: "1px solid rgba(226,183,20,0.3)",
+              color: "#e2b714",
+              fontSize: "13px",
+              fontWeight: "700",
+              padding: "5px 16px",
+              borderRadius: "100px",
+              letterSpacing: "2px",
+              textTransform: "uppercase",
+              alignSelf: "flex-start",
+            }}
+          >
+            AI NATIVE SCORE
+          </div>
+          <div
+            style={{
+              fontSize: "40px",
+              fontWeight: "800",
+              color: "#f1f5f9",
+              lineHeight: 1.2,
+            }}
+          >
+            My AI Readiness:
+          </div>
+          <div
+            style={{
+              fontSize: "36px",
+              fontWeight: "700",
+              color: meta.color,
+              lineHeight: 1.2,
+            }}
+          >
+            {score}/30 — {meta.label}
+          </div>
+          <div
+            style={{
+              fontSize: "20px",
+              color: "#94a3b8",
+              lineHeight: 1.4,
+              marginTop: "8px",
+            }}
+          >
+            How AI-ready is YOUR business? Take the free 2-minute assessment.
+          </div>
+        </div>
+
+        {/* Branding */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "30px",
+            right: "40px",
+            fontSize: "16px",
+            color: "#e2b714",
+            fontWeight: "600",
+          }}
+        >
+          ai-native-playbook.com/score
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/src/app/sitemap-pages.xml/route.ts
+++ b/src/app/sitemap-pages.xml/route.ts
@@ -16,6 +16,8 @@ const STATIC_PAGES: Array<{ path: string; lastmod: string }> = [
   { path: "en/blog", lastmod: "2026-03-10" },
   { path: "en/patterns", lastmod: "2026-03-11" },
   { path: "en/free-guide", lastmod: "2026-03-12" },
+  { path: "en/score", lastmod: "2026-03-25" },
+  { path: "ja/score", lastmod: "2026-03-25" },
   { path: "en/terms", lastmod: "2025-01-01" },
   { path: "en/privacy", lastmod: "2025-01-01" },
   { path: "en/refund", lastmod: "2025-01-01" },


### PR DESCRIPTION
## Summary
- Add `/score` page: 10-question AI readiness self-assessment tool (client-side, no API needed for scoring)
- Three result tiers (Beginner 0-10 / Adopter 11-20 / Native 21-30) with personalized playbook recommendations
- Social share buttons (X, LinkedIn) for viral distribution
- Email capture form connected to existing `/api/subscribe` endpoint (Brevo list)
- Full SEO metadata targeting "AI readiness assessment" (2,400 monthly searches)
- Dark theme matching existing ainp design system (navy/gold)
- Built for both en/ja locales (content is English-first, ja translation follow-up)

## Test plan
- [ ] Visit /en/score — verify quiz loads with progress bar
- [ ] Complete all 10 questions — verify auto-advance and score calculation
- [ ] Check result page shows correct tier for different score ranges
- [ ] Test social share buttons open correct pre-filled URLs
- [ ] Test email capture form submits to /api/subscribe
- [ ] Verify SEO meta tags (title, description, OG, Twitter card)
- [ ] Test back button navigation during quiz
- [ ] Test retake button on results page
- [ ] Mobile responsive check

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched AI Native Score assessment: interactive 10-question quiz, instant scoring, tiered results, recommendations, retake flow, and shareable result preview via URL parameters.
  * Integrated email capture form with loading/success/error states.

* **SEO & Sharing**
  * Dynamic page metadata and Open Graph images (personalized when a score is present).
  * Share links for X and LinkedIn.

* **Sitemap**
  * Added localized /score entries to the sitemap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->