### PR TITLE
feat(blog): add Score + Pricing CTA to all blog posts

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import { books } from "@/lib/products";
 import BlogInlineCTA from "@/components/BlogInlineCTA";
+import BlogBottomCTA from "@/components/BlogBottomCTA";
 import { splitContentAtMidpoint } from "@/lib/blog-content-utils";
 
 export const revalidate = 60; // 60초마다 재검증 — 예약 시각 도래 시 자동 공개
@@ -259,6 +260,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           );
         })()}
       </article>
+
+      {/* Score + Pricing CTA */}
+      <BlogBottomCTA locale={locale} />
+
       {/* Product CTA */}
       <div className="mt-12 p-6 bg-gradient-to-r from-gold/10 to-gold/5 border border-gold/20 rounded-2xl">
         <h3 className="text-lg font-bold mb-2">Ready to Execute These Frameworks with AI?</h3>

--- a/src/components/BlogBottomCTA.tsx
+++ b/src/components/BlogBottomCTA.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+/**
+ * Bottom CTA banner for blog posts — drives traffic to /score and /pricing.
+ * Rendered once per blog post, between article content and existing product CTA.
+ * Server component — uses next-intl server translations.
+ */
+export default function BlogBottomCTA({ locale }: { locale: string }) {
+  const t = useTranslations("blogBottomCta");
+
+  const scoreHref = `/${locale}/score`;
+  const pricingHref = `/${locale}/pricing`;
+
+  return (
+    <div
+      className="mt-12 rounded-2xl border border-gold/20 bg-gradient-to-br from-navy-light/80 to-navy-dark/60 p-8 relative overflow-hidden"
+      role="complementary"
+      aria-label="Next steps"
+    >
+      {/* Decorative accent */}
+      <div
+        className="absolute -top-8 -right-8 w-40 h-40 bg-gold/5 rounded-full pointer-events-none"
+        aria-hidden="true"
+      />
+
+      <div className="relative">
+        <h3 className="text-xl font-bold text-text-primary mb-2">
+          {t("heading")}
+        </h3>
+        <p className="text-sm text-text-secondary leading-relaxed mb-6 max-w-xl">
+          {t("description")}
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-4">
+          {/* Primary CTA — AI Native Score (free, low friction) */}
+          <div className="flex flex-col items-start gap-1.5">
+            <Link
+              href={scoreHref}
+              className="inline-flex items-center gap-2 rounded-xl bg-gold px-6 py-3 text-sm font-bold text-navy-dark transition-colors hover:bg-gold-light focus:outline-none focus:ring-2 focus:ring-gold/60"
+            >
+              <svg
+                className="h-4 w-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                />
+              </svg>
+              {t("scoreCta")}
+            </Link>
+            <span className="text-xs text-text-muted ml-1">
+              {t("scoreSubtext")}
+            </span>
+          </div>
+
+          {/* Secondary CTA — Pricing */}
+          <div className="flex flex-col items-start gap-1.5">
+            <Link
+              href={pricingHref}
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-6 py-3 text-sm font-semibold text-text-secondary transition-all hover:border-gold/30 hover:text-gold focus:outline-none focus:ring-2 focus:ring-gold/60"
+            >
+              {t("pricingCta")}
+              <svg
+                className="h-4 w-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
+            </Link>
+            <span className="text-xs text-text-muted ml-1">
+              {t("pricingSubtext")}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -306,6 +306,14 @@
     "ctaButton": "Get My Free Guide →",
     "label": "Free AI Starter Guide"
   },
+  "blogBottomCta": {
+    "heading": "Take the Next Step with AI Native Playbook",
+    "description": "Discover how AI-ready your business is, or explore our complete framework library to accelerate your transformation.",
+    "scoreCta": "Get Your Free AI Native Score",
+    "scoreSubtext": "2-min assessment — instant results",
+    "pricingCta": "View All Playbooks & Pricing",
+    "pricingSubtext": "6 volumes — from $17"
+  },
   "freeGuide": {
     "socialProof": "Downloaded by 500+ professionals",
     "ctaButton": "Get My Free Guide →",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -306,6 +306,14 @@
     "ctaButton": "無料ガイドを入手 →",
     "label": "無料AIスタータガイド"
   },
+  "blogBottomCta": {
+    "heading": "AI Native Playbookで次のステップへ",
+    "description": "ビジネスのAI準備度を確認するか、完全なフレームワークライブラリを探索しましょう。",
+    "scoreCta": "無料AI Nativeスコア診断",
+    "scoreSubtext": "2分の診断 — 即時結果",
+    "pricingCta": "全プレイブック＆価格を見る",
+    "pricingSubtext": "6巻 — $17から"
+  },
   "freeGuide": {
     "socialProof": "500人以上のプロフェッショナルがダウンロード済み",
     "ctaButton": "無料ガイドを入手 →",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -306,6 +306,14 @@
     "ctaButton": "무료 가이드 받기 →",
     "label": "무료 AI 스타터 가이드"
   },
+  "blogBottomCta": {
+    "heading": "AI Native Playbook으로 다음 단계로",
+    "description": "우리 비즈니스의 AI 준비도를 확인하거나, 전체 프레임워크 라이브러리를 탐색해 보세요.",
+    "scoreCta": "무료 AI Native Score 진단",
+    "scoreSubtext": "2분 진단 — 즉시 결과 확인",
+    "pricingCta": "전체 플레이북 & 가격 보기",
+    "pricingSubtext": "6권 — $17부터"
+  },
   "freeGuide": {
     "socialProof": "500명 이상의 전문가가 다운로드했습니다",
     "ctaButton": "무료 가이드 받기 →",


### PR DESCRIPTION
## Summary
- Add `BlogBottomCTA` component with two CTAs: **AI Native Score** (primary, /score) and **Pricing** (secondary, /pricing)
- Integrated into blog post layout (`[slug]/page.tsx`) so all 46+ posts get the CTA automatically
- Full i18n support (en/ko/ja) via `blogBottomCta` namespace in messages

## What it does
- Renders between the article content and the existing product CTA section
- Primary CTA drives free AI Native Score assessment (low friction, lead capture)
- Secondary CTA links to pricing page for readers ready to buy
- Styled consistently with existing design system (gold accents, navy background)

## Test plan
- [ ] Verify CTA renders on blog post pages in all 3 locales
- [ ] Verify /score and /pricing links are correct per locale
- [ ] Verify no layout shift or style conflicts with existing CTAs
- [ ] Verify TypeScript compilation passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Next steps" call-to-action section at the bottom of blog posts with links to score and pricing pages.
  * Included multi-language support for English, Japanese, and Korean.
  * Features responsive design and accessible navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->