### PR TITLE
feat: free-guide to pricing conversion CTAs

### DIFF
--- a/src/app/[locale]/free-guide/page.tsx
+++ b/src/app/[locale]/free-guide/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
 import dynamic from "next/dynamic";
@@ -324,6 +325,42 @@ export default async function FreeGuidePage({
               Claude, ChatGPT, Gemini — use your preferred tool.
             </p>
           </div>
+        </div>
+      </section>
+
+      {/* Upsell CTA — Full Playbook + Pricing */}
+      <section className="max-w-3xl mx-auto px-4 mt-20">
+        <div className="bg-gradient-to-br from-gold/5 to-gold/10 border border-gold/20 rounded-2xl p-8 md:p-10 text-center">
+          <h2 className="text-2xl md:text-3xl font-bold mb-4">
+            Want the Full{" "}
+            <span className="gradient-gold">AI Automation System</span>?
+          </h2>
+          <p className="text-text-secondary max-w-xl mx-auto mb-6 leading-relaxed">
+            This free guide covers the basics. Our complete Playbook series
+            gives you 6 world-class frameworks, ready-to-use AI agent skills,
+            and step-by-step implementation guides to fully automate your
+            business.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              href="/pricing"
+              className="inline-flex items-center gap-2 px-8 py-3.5 rounded-xl font-bold text-base transition-all transform hover:scale-105 bg-gold text-navy-dark hover:bg-gold-light"
+            >
+              View Plans & Pricing
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+              </svg>
+            </Link>
+            <Link
+              href="/products"
+              className="inline-flex items-center gap-2 px-6 py-3 border border-gold/30 rounded-xl font-semibold text-sm text-gold hover:bg-gold/10 hover:border-gold/50 transition-all"
+            >
+              Explore All Products
+            </Link>
+          </div>
+          <p className="text-xs text-text-muted mt-4">
+            30-day money-back guarantee on all products.
+          </p>
         </div>
       </section>
     </div>

--- a/src/app/[locale]/free-guide/thank-you/page.tsx
+++ b/src/app/[locale]/free-guide/thank-you/page.tsx
@@ -168,14 +168,32 @@ export default async function ThankYouPage({
           </ul>
         </div>
 
-        {/* Secondary CTA — products */}
-        <div className="mt-8 pt-8 border-t border-white/10">
-          <Link
-            href="/products"
-            className="inline-flex items-center gap-2 px-6 py-3 border border-gold/30 rounded-xl font-semibold text-sm text-gold hover:bg-gold/10 hover:border-gold/50 transition-all"
-          >
-            {t("exploreProducts")}
-          </Link>
+        {/* Upsell CTA — Pricing */}
+        <div className="mt-8 bg-gradient-to-br from-gold/5 to-gold/10 border border-gold/20 rounded-2xl p-6 text-center">
+          <h2 className="text-lg font-bold mb-2">
+            Ready for the Full System?
+          </h2>
+          <p className="text-sm text-text-secondary mb-4 max-w-md mx-auto">
+            Your free guide is just the beginning. Unlock all 6 frameworks,
+            AI agent skills, and complete implementation guides.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Link
+              href="/pricing"
+              className="inline-flex items-center gap-2 px-8 py-3 rounded-xl font-bold text-sm transition-all transform hover:scale-105 bg-gold text-navy-dark hover:bg-gold-light"
+            >
+              View Plans & Pricing
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+              </svg>
+            </Link>
+            <Link
+              href="/products"
+              className="inline-flex items-center gap-2 px-6 py-3 border border-gold/30 rounded-xl font-semibold text-sm text-gold hover:bg-gold/10 hover:border-gold/50 transition-all"
+            >
+              {t("exploreProducts")}
+            </Link>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- **free-guide page**: Added upsell section after trust signals with "View Plans & Pricing" primary CTA and "Explore All Products" secondary CTA
- **thank-you page**: Replaced generic "Explore Products" link with a prominent pricing upsell card containing "View Plans & Pricing" CTA + secondary products link

## Context
Completes the blog→free-guide→pricing conversion funnel:
- Blog posts (46 articles) → BlogBottomCTA (PR #260) → free-guide
- free-guide page → **NEW: pricing CTA** → pricing (PR #261 CTA enhancements)
- thank-you page (post-download) → **NEW: pricing upsell** → pricing

## Notes
- /score page does not exist (404), so no score link added
- Sitemap already includes /en/free-guide (confirmed)
- No price changes — links only
- Pre-existing TS errors in test files unrelated to this PR

## Test plan
- [ ] Verify /en/free-guide renders upsell section at bottom
- [ ] Verify "View Plans & Pricing" links to /pricing
- [ ] Verify /en/free-guide/thank-you shows pricing upsell card
- [ ] Verify mobile responsive layout for CTA buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)