### PR TITLE
feat: add FAQPage JSON-LD to pricing, enhance FAQ schema

### DIFF
--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -135,6 +135,7 @@ export default async function FaqPage({ params }: { params: Promise<{ locale: st
     name: t("title"),
     description: t("subtitle"),
     url: canonicalFaqUrl,
+    dateModified: "2026-03-26",
     inLanguage: locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US",
     isPartOf: { "@id": `${SITE_URL}/#website` },
     publisher: {

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -147,6 +147,24 @@ export default async function PricingPage({
 
   const canonicalPricingUrl = `${SITE_URL}/${locale}/pricing`;
 
+  const pricingFaqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    name: "Pricing FAQ — AI Native Playbook Series",
+    url: canonicalPricingUrl,
+    dateModified: "2026-03-26",
+    inLanguage: locale === "ja" ? "ja-JP" : "en-US",
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    mainEntity: pricingFaqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.a,
+      },
+    })),
+  };
+
   const offerCatalogJsonLd = {
     "@context": "https://schema.org",
     "@type": "OfferCatalog",
@@ -195,6 +213,12 @@ export default async function PricingPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: escapeJsonLd(JSON.stringify(offerCatalogJsonLd)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: escapeJsonLd(JSON.stringify(pricingFaqJsonLd)),
         }}
       />
 


### PR DESCRIPTION
## Summary
- **Pricing page**: Added FAQPage JSON-LD structured data covering all 7 pricing FAQ items, enabling Google rich snippet eligibility for `/en/pricing`
- **FAQ page**: Added `dateModified` field to existing FAQPage schema for freshness signals
- Schema-only changes; no content modifications

## Test plan
- [ ] Verify `/en/faq` JSON-LD output includes `dateModified` field
- [ ] Verify `/en/pricing` renders 3 JSON-LD blocks (BreadcrumbList, OfferCatalog, FAQPage)
- [ ] Validate both pages with Google Rich Results Test (https://search.google.com/test/rich-results)
- [ ] Confirm no visual/content changes on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FAQ page schema to include modification date information
  * Integrated structured data markup into pricing page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->