### PR TITLE
seo: add /ja URLs to sitemap-pages.xml

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -55,12 +55,16 @@ describe("sitemap-pages.xml", () => {
     expect(xml).toContain("/en/free-guide");
   });
 
-  it("does not include /ja/ URLs", async () => {
+  it("includes /ja/ URLs", async () => {
     const { GET } = await import("@/app/sitemap-pages.xml/route");
     const response = GET();
     const xml = await response.text();
 
-    expect(xml).not.toContain("/ja/");
+    expect(xml).toContain("/ja/pricing");
+    expect(xml).toContain("/ja/about");
+    expect(xml).toContain("/ja/faq");
+    expect(xml).toContain("/ja/blog");
+    expect(xml).toContain("/ja/free-guide");
   });
 
   it("does not include /ko/ URLs", async () => {

--- a/src/app/sitemap-pages.xml/route.ts
+++ b/src/app/sitemap-pages.xml/route.ts
@@ -7,6 +7,7 @@ const BASE_URL =
 // Static pages with their last-modified dates (en prefix canonical)
 const STATIC_PAGES: Array<{ path: string; lastmod: string }> = [
   { path: "", lastmod: "2026-03-08" },
+  // English pages
   { path: "en", lastmod: "2026-03-08" },
   { path: "en/products", lastmod: "2026-03-08" },
   { path: "en/pricing", lastmod: "2026-03-11" },
@@ -19,6 +20,19 @@ const STATIC_PAGES: Array<{ path: string; lastmod: string }> = [
   { path: "en/terms", lastmod: "2025-01-01" },
   { path: "en/privacy", lastmod: "2025-01-01" },
   { path: "en/refund", lastmod: "2025-01-01" },
+  // Japanese pages
+  { path: "ja", lastmod: "2026-03-26" },
+  { path: "ja/pricing", lastmod: "2026-03-26" },
+  { path: "ja/about", lastmod: "2026-03-26" },
+  { path: "ja/faq", lastmod: "2026-03-26" },
+  { path: "ja/blog", lastmod: "2026-03-26" },
+  { path: "ja/free-guide", lastmod: "2026-03-26" },
+  { path: "ja/patterns", lastmod: "2026-03-26" },
+  { path: "ja/products", lastmod: "2026-03-26" },
+  { path: "ja/bundle", lastmod: "2026-03-26" },
+  { path: "ja/terms", lastmod: "2026-03-26" },
+  { path: "ja/privacy", lastmod: "2026-03-26" },
+  { path: "ja/refund", lastmod: "2026-03-26" },
 ];
 
 function buildUrl(path: string): string {
@@ -30,15 +44,19 @@ function urlEntry(loc: string, lastmod: string): string {
 }
 
 export function GET() {
-  const patternEntries = patterns.map((p) =>
+  const enPatternEntries = patterns.map((p) =>
     urlEntry(buildUrl(`en/patterns/${p.slug}`), "2026-03-11")
+  );
+
+  const jaPatternEntries = patterns.map((p) =>
+    urlEntry(buildUrl(`ja/patterns/${p.slug}`), "2026-03-26")
   );
 
   const staticEntries = STATIC_PAGES.map((page) =>
     urlEntry(buildUrl(page.path), page.lastmod)
   );
 
-  const allEntries = [...staticEntries, ...patternEntries].join("\n");
+  const allEntries = [...staticEntries, ...enPatternEntries, ...jaPatternEntries].join("\n");
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">


### PR DESCRIPTION
## Summary
- Add all /ja static page URLs to sitemap-pages.xml (home, pricing, about, faq, blog, free-guide, patterns, products, bundle, terms, privacy, refund)
- Add /ja/patterns/* entries for all pattern slugs
- Update test to verify /ja URLs are now included (previously asserted they were excluded)

## Context
- hreflang tags already declare en/ja/x-default on all pages
- Sitemap only contained /en URLs, meaning Google had no sitemap signal to discover /ja pages
- This aligns sitemap with hreflang for proper Japanese locale indexing
- Supports KR2-6: ainp visitors 2,000/month

## Test plan
- [x] All 15 sitemap tests pass (vitest)
- [ ] After merge, verify /sitemap-pages.xml includes /ja URLs on production
- [ ] Monitor Google Search Console for /ja page indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended sitemap to include Japanese language pages (pricing, about, FAQ, blog, free-guide) and Japanese pattern URLs, ensuring better search engine visibility for Japanese content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->