### PR TITLE
seo(blog): enhance Article JSON-LD with dateModified

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       description: post.description,
       type: "article",
       publishedTime: post.date,
-      modifiedTime: post.date,
+      modifiedTime: post.updated ?? post.date,
       url: canonicalUrl,
       locale: locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US",
       siteName: "AI Native Playbook Series",
@@ -137,7 +137,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     headline: post.title,
     description: post.description,
     datePublished: post.date,
-    dateModified: post.date,
+    dateModified: post.updated ?? post.date,
     image: {
       "@type": "ImageObject",
       url: locale === "en"
@@ -168,6 +168,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       "@type": "WebPage",
       "@id": locale === "en" ? `${siteUrl}/en/blog/${slug}` : `${siteUrl}/${locale}/blog/${slug}`,
     },
+    articleSection: post.category,
     keywords: post.tags.join(", "),
     wordCount: Math.round(post.content.split(/\s+/).length),
     speakable: {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -20,6 +20,8 @@ export interface BlogPost {
   published?: boolean;
   /** ISO 8601 예약 발행 시각. 미래이면 비공개. 비어있거나 미설정이면 즉시 공개 */
   scheduledAt?: string;
+  /** 최종 수정일. frontmatter `updated` 필드. 미설정 시 date와 동일 */
+  updated?: string;
 }
 
 /**
@@ -75,6 +77,7 @@ export function getAllPosts(): Omit<BlogPost, "content">[] {
         locale: (data.locale as string | undefined) ?? "en",
         published: data.published as boolean | undefined,
         scheduledAt: data.scheduledAt as string | undefined,
+        updated: (data.updated as string | undefined) ?? undefined,
       };
     })
     .filter((post) => isPostVisible(post))
@@ -100,6 +103,7 @@ export function getPostBySlug(slug: string): BlogPost | null {
     locale: (data.locale as string | undefined) ?? "en",
     published: data.published as boolean | undefined,
     scheduledAt: data.scheduledAt as string | undefined,
+    updated: (data.updated as string | undefined) ?? undefined,
   };
 
   // 비공개 포스트 직접 접근 차단


### PR DESCRIPTION
## Summary
- Parse `updated` frontmatter field from blog posts for accurate `dateModified` in Article JSON-LD and OpenGraph metadata
- Add `articleSection` (category) property to BlogPosting structured data
- 5 posts already have `updated` dates; others gracefully fall back to publish date

## Changes
- `src/lib/blog.ts`: Added `updated` optional field to `BlogPost` interface + parsing in `getPostBySlug` and `getAllPosts`
- `src/app/[locale]/blog/[slug]/page.tsx`: Use `post.updated ?? post.date` for `dateModified` in JSON-LD and OG metadata; added `articleSection`

## Impact
- Google can distinguish between publish and modification dates for rich snippets
- Supports KR2-6 (ainp organic traffic growth)

## Test plan
- [ ] Verify TypeScript compiles without new errors
- [ ] Check blog post with `updated` field renders correct `dateModified` in page source
- [ ] Check blog post without `updated` field falls back to `date` for `dateModified`
- [ ] Validate JSON-LD with Google Rich Results Test

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now track and display modification dates alongside publication dates.
  * Blog post schema now includes category information for improved search engine visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->