### PR TITLE
feat: add loading.tsx skeletons for core pages

### DIFF
--- a/src/app/[locale]/blog/loading.tsx
+++ b/src/app/[locale]/blog/loading.tsx
@@ -1,0 +1,48 @@
+export default function BlogLoading() {
+  return (
+    <div className="min-h-screen bg-navy">
+      {/* Header skeleton */}
+      <section className="pt-20 pb-8 px-6">
+        <div className="max-w-3xl mx-auto text-center space-y-4">
+          <div className="h-10 w-1/2 mx-auto rounded-lg bg-white/5 animate-pulse" />
+          <div className="h-5 w-2/3 mx-auto rounded bg-white/5 animate-pulse" />
+        </div>
+      </section>
+
+      {/* Filter bar skeleton */}
+      <section className="pb-6 px-6">
+        <div className="max-w-5xl mx-auto flex gap-3 overflow-hidden">
+          {[...Array(5)].map((_, i) => (
+            <div
+              key={i}
+              className="h-9 w-24 rounded-full bg-white/5 animate-pulse shrink-0"
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Blog post grid skeleton */}
+      <section className="pb-16 px-6">
+        <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <article
+              key={i}
+              className="rounded-2xl bg-white/5 overflow-hidden animate-pulse"
+            >
+              <div className="h-44 bg-white/5" />
+              <div className="p-5 space-y-3">
+                <div className="flex gap-2">
+                  <div className="h-5 w-16 rounded-full bg-white/5" />
+                  <div className="h-5 w-20 rounded-full bg-white/5" />
+                </div>
+                <div className="h-6 w-full rounded bg-white/5" />
+                <div className="h-4 w-full rounded bg-white/5" />
+                <div className="h-4 w-2/3 rounded bg-white/5" />
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/free-guide/loading.tsx
+++ b/src/app/[locale]/free-guide/loading.tsx
@@ -1,0 +1,45 @@
+export default function FreeGuideLoading() {
+  return (
+    <div className="min-h-screen bg-navy">
+      {/* Hero skeleton */}
+      <section className="pt-20 pb-16 px-6">
+        <div className="max-w-3xl mx-auto text-center space-y-6">
+          <div className="h-6 w-40 mx-auto rounded-full bg-gold/10 animate-pulse" />
+          <div className="h-10 w-3/4 mx-auto rounded-lg bg-white/5 animate-pulse" />
+          <div className="h-6 w-2/3 mx-auto rounded bg-white/5 animate-pulse" />
+          <div className="h-5 w-1/2 mx-auto rounded bg-white/5 animate-pulse" />
+        </div>
+      </section>
+
+      {/* Form skeleton */}
+      <section className="pb-16 px-6">
+        <div className="max-w-md mx-auto rounded-2xl bg-white/5 p-8 space-y-5 animate-pulse">
+          <div className="h-6 w-2/3 mx-auto rounded bg-white/5" />
+          <div className="space-y-4">
+            <div className="h-12 w-full rounded-lg bg-white/5" />
+            <div className="h-12 w-full rounded-lg bg-white/5" />
+            <div className="h-14 w-full rounded-xl bg-gold/10" />
+          </div>
+          <div className="h-4 w-3/4 mx-auto rounded bg-white/5" />
+        </div>
+      </section>
+
+      {/* Benefits skeleton */}
+      <section className="pb-16 px-6">
+        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[...Array(3)].map((_, i) => (
+            <div
+              key={i}
+              className="rounded-2xl bg-white/5 p-6 space-y-3 animate-pulse"
+            >
+              <div className="h-10 w-10 rounded-lg bg-gold/10" />
+              <div className="h-5 w-2/3 rounded bg-white/5" />
+              <div className="h-4 w-full rounded bg-white/5" />
+              <div className="h-4 w-3/4 rounded bg-white/5" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/loading.tsx
+++ b/src/app/[locale]/loading.tsx
@@ -1,0 +1,33 @@
+export default function LocaleLoading() {
+  return (
+    <div className="min-h-screen bg-navy">
+      {/* Hero skeleton */}
+      <section className="pt-20 pb-16 px-6">
+        <div className="max-w-4xl mx-auto text-center space-y-6">
+          <div className="h-10 w-3/4 mx-auto rounded-lg bg-white/5 animate-pulse" />
+          <div className="h-6 w-2/3 mx-auto rounded bg-white/5 animate-pulse" />
+          <div className="h-6 w-1/2 mx-auto rounded bg-white/5 animate-pulse" />
+          <div className="h-14 w-48 mx-auto rounded-xl bg-gold/10 animate-pulse mt-8" />
+        </div>
+      </section>
+
+      {/* Product cards skeleton */}
+      <section className="pb-16 px-6">
+        <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[...Array(3)].map((_, i) => (
+            <div
+              key={i}
+              className="rounded-2xl bg-white/5 p-6 space-y-4 animate-pulse"
+            >
+              <div className="h-48 rounded-lg bg-white/5" />
+              <div className="h-5 w-3/4 rounded bg-white/5" />
+              <div className="h-4 w-full rounded bg-white/5" />
+              <div className="h-4 w-2/3 rounded bg-white/5" />
+              <div className="h-10 w-32 rounded-lg bg-gold/10 mt-4" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/pricing/loading.tsx
+++ b/src/app/[locale]/pricing/loading.tsx
@@ -1,0 +1,45 @@
+export default function PricingLoading() {
+  return (
+    <div className="min-h-screen bg-navy">
+      {/* Header skeleton */}
+      <section className="pt-20 pb-12 px-6">
+        <div className="max-w-3xl mx-auto text-center space-y-4">
+          <div className="h-10 w-2/3 mx-auto rounded-lg bg-white/5 animate-pulse" />
+          <div className="h-5 w-1/2 mx-auto rounded bg-white/5 animate-pulse" />
+        </div>
+      </section>
+
+      {/* Bundle card skeleton */}
+      <section className="pb-8 px-6">
+        <div className="max-w-2xl mx-auto rounded-2xl border border-gold/20 bg-white/5 p-8 space-y-6 animate-pulse">
+          <div className="h-8 w-1/2 mx-auto rounded bg-white/5" />
+          <div className="h-12 w-32 mx-auto rounded bg-gold/10" />
+          <div className="space-y-2">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-4 w-3/4 mx-auto rounded bg-white/5" />
+            ))}
+          </div>
+          <div className="h-14 w-56 mx-auto rounded-xl bg-gold/10" />
+        </div>
+      </section>
+
+      {/* Individual products skeleton */}
+      <section className="pb-16 px-6">
+        <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              className="rounded-2xl bg-white/5 p-6 space-y-4 animate-pulse"
+            >
+              <div className="h-40 rounded-lg bg-white/5" />
+              <div className="h-5 w-3/4 rounded bg-white/5" />
+              <div className="h-4 w-full rounded bg-white/5" />
+              <div className="h-8 w-20 rounded bg-gold/10" />
+              <div className="h-10 w-full rounded-lg bg-gold/10" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add page-specific skeleton loading states for 4 core pages: homepage (`/[locale]`), pricing, blog, and free-guide
- Each skeleton matches the page layout structure (hero, cards, forms, grids) for smooth perceived loading
- Uses existing design tokens (`bg-navy`, `bg-white/5`, `bg-gold/10`) with `animate-pulse`

## Pages covered
| Page | Skeleton content |
|------|-----------------|
| `/[locale]` (home) | Hero + 3-column product cards |
| `/[locale]/pricing` | Header + bundle card + 6 product cards |
| `/[locale]/blog` | Header + filter bar + 6 article cards |
| `/[locale]/free-guide` | Hero + form + 3 benefit cards |

## Notes
- `/[locale]/score` page does not exist in the codebase, skipped
- Root `src/app/loading.tsx` already exists (simple spinner), unchanged
- Build verified locally - no errors

## Test plan
- [ ] Navigate between pages and verify skeleton appears during transitions
- [ ] Verify skeletons match the general layout of each page
- [ ] Check mobile responsiveness of skeleton layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)