### PR TITLE
feat: optimize meta tags for 6 product pages

### DIFF
--- a/src/app/[locale]/products/[slug]/page.tsx
+++ b/src/app/[locale]/products/[slug]/page.tsx
@@ -19,6 +19,38 @@ export function generateStaticParams() {
   );
 }
 
+/* Per-product SEO meta descriptions with purchase CTA — max 155 chars */
+const productMetaDescriptions: Record<string, string> = {
+  "ai-marketing-architect":
+    "AI Marketing Architect: Automate DotCom Secrets funnels with AI. Value Ladder, Hook-Story-Offer & email sequences — $17 PDF guide. Download now.",
+  "ai-brand-architect":
+    "AI Brand Architect: Build a movement with Expert Secrets + AI. Mass Movement design, Epiphany Bridge & Perfect Webinar script — $17 PDF. Buy now.",
+  "ai-traffic-architect":
+    "AI Traffic Architect: Automate Traffic Secrets with AI. Dream 100 strategy, multi-platform content & follow-up funnels — $17 PDF. Download now.",
+  "ai-story-architect":
+    "AI Story Architect: Turn Copywriting Secrets into AI-powered sales copy. Headlines, Hero's Journey & FRED targeting — $17 PDF guide. Buy now.",
+  "ai-startup-architect":
+    "AI Startup Architect: Automate Product Launch Formula with AI. Prelaunch sequences, 7-day launch emails & evergreen funnels — $17 PDF. Buy now.",
+  "ai-content-architect":
+    "AI Content Architect: Scale online writing with Nicolas Cole's system + AI. Category design, content atomization & monetization — $17 PDF. Buy now.",
+};
+
+/* Per-product OG descriptions — shorter, social-optimized */
+const productOgDescriptions: Record<string, string> = {
+  "ai-marketing-architect":
+    "Automate Russell Brunson's DotCom Secrets with AI. Build funnels, email sequences & value ladders — $17 instant PDF download.",
+  "ai-brand-architect":
+    "Build a brand movement with Expert Secrets + AI. Generate webinar scripts & belief systems automatically — $17 PDF guide.",
+  "ai-traffic-architect":
+    "Automate Traffic Secrets with AI. Dream 100 lists, platform-specific content & follow-up funnels — $17 instant download.",
+  "ai-story-architect":
+    "Turn Jim Edwards' Copywriting Secrets into AI-powered sales copy. Headlines, stories & CTAs on autopilot — $17 PDF guide.",
+  "ai-startup-architect":
+    "Automate Jeff Walker's Product Launch Formula with AI. Prelaunch content, launch emails & scaling — $17 PDF guide.",
+  "ai-content-architect":
+    "Scale your writing with Nicolas Cole's system + AI. Category design, idea generation & 5-platform atomization — $17 PDF.",
+};
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug, locale } = await params;
   const book = getBookBySlug(slug);
@@ -28,14 +60,25 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const canonicalUrl = locale === "en"
     ? `${siteUrl}/en/products/${slug}`
     : `${siteUrl}/${locale}/products/${slug}`;
+
+  /* Title: keep under 60 chars — truncate subtitle if needed */
+  const fullTitle = `${book.title} — ${book.subtitle}`;
+  const title = fullTitle.length <= 60 ? fullTitle : `${book.title} | AI Business Guide`;
+
+  /* Description: use CTA-optimized per-product description */
+  const description = productMetaDescriptions[slug] ?? book.shortDescription;
+  const ogDescription = productOgDescriptions[slug] ?? description;
+
   return {
-    title: `${book.title} — ${book.subtitle}`,
-    description: book.shortDescription,
+    title,
+    description,
     keywords: [
       book.title,
       book.framework,
       `${book.framework} AI`,
       `${book.framework} automation`,
+      `${book.framework} AI guide`,
+      `buy ${book.title}`,
       "AI business automation",
       "AI marketing playbook",
       "AI native business guide",
@@ -56,8 +99,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       },
     },
     openGraph: {
-      title: `${book.title} — ${book.subtitle}`,
-      description: book.shortDescription,
+      title,
+      description: ogDescription,
       type: "website",
       locale: locale === "ko" ? "ko_KR" : locale === "ja" ? "ja_JP" : "en_US",
       siteName: "AI Native Playbook Series",
@@ -73,8 +116,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     twitter: {
       card: "summary_large_image",
-      title: `${book.title} — ${book.subtitle}`,
-      description: book.shortDescription,
+      title,
+      description: ogDescription,
       images: [`${siteUrl}/og-image`],
     },
   };
@@ -103,10 +146,12 @@ export default async function ProductPage({ params }: Props) {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Product",
+    additionalType: "https://schema.org/DigitalDocument",
     name: book.title,
-    description: book.shortDescription,
-    url: `${siteUrl}/products/${slug}`,
+    description: productMetaDescriptions[slug] ?? book.shortDescription,
+    url: `${siteUrl}/${locale}/products/${slug}`,
     sku: `AIA-VOL${book.vol}`,
+    mpn: `AINP-VOL${book.vol}`,
     image: {
       "@type": "ImageObject",
       url: `${siteUrl}/opengraph-image`,
@@ -116,6 +161,7 @@ export default async function ProductPage({ params }: Props) {
     itemCondition: "https://schema.org/NewCondition",
     brand: { "@type": "Brand", name: "AI Native Playbook Series" },
     category: "Digital Download / Business Guide",
+    inLanguage: locale === "ko" ? "ko" : locale === "ja" ? "ja" : "en",
     aggregateRating: {
       "@type": "AggregateRating",
       ratingValue: "4.8",
@@ -140,22 +186,24 @@ export default async function ProductPage({ params }: Props) {
     offers: [
       {
         "@type": "Offer",
-        name: "Individual",
+        name: "Individual PDF Guide",
         price: "17",
         priceCurrency: "USD",
         availability: "https://schema.org/InStock",
-        url: `${siteUrl}/products/${slug}`,
+        url: `${siteUrl}/${locale}/products/${slug}`,
         priceValidUntil: "2026-12-31",
+        itemCondition: "https://schema.org/NewCondition",
         seller: { "@type": "Organization", name: "AI Native Playbook Series", url: siteUrl },
       },
       {
         "@type": "Offer",
-        name: "Complete Bundle (6 Books)",
+        name: "Complete Bundle (All 6 Books)",
         price: "47",
         priceCurrency: "USD",
         availability: "https://schema.org/InStock",
-        url: `${siteUrl}/bundle`,
+        url: `${siteUrl}/${locale}/bundle`,
         priceValidUntil: "2026-12-31",
+        itemCondition: "https://schema.org/NewCondition",
         seller: { "@type": "Organization", name: "AI Native Playbook Series", url: siteUrl },
       },
     ],


### PR DESCRIPTION
## Summary
- Add per-product CTA-optimized meta descriptions (max 155 chars) for all 6 books
- Add separate social-optimized OG descriptions for better sharing CTR
- Fix title overflow: truncate to 60 chars for AI Startup Architect (63ch) and AI Content Architect (66ch)
- Add purchase-intent keywords (`buy {title}`, `{framework} AI guide`)
- Enhance JSON-LD: `additionalType: DigitalDocument`, `mpn`, `inLanguage`, locale-aware offer URLs
- No price changes, no body content changes — meta + schema only

## Products covered
1. AI Marketing Architect (Vol.1)
2. AI Brand Architect (Vol.2)
3. AI Traffic Architect (Vol.3)
4. AI Story Architect (Vol.4)
5. AI Startup Architect (Vol.5)
6. AI Content Architect (Vol.6)

## Test plan
- [ ] Verify `<title>` tag under 60 chars for all 6 products
- [ ] Verify `<meta name="description">` contains CTA text
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Check OG tags render correctly in social share debuggers
- [ ] Confirm no visual/functional changes to product pages

Generated with [Claude Code](https://claude.com/claude-code)