### PR TITLE
feat(patterns): optimize meta tags and JSON-LD for SEO

### DIFF
--- a/src/app/[locale]/patterns/[slug]/page.tsx
+++ b/src/app/[locale]/patterns/[slug]/page.tsx
@@ -31,8 +31,8 @@ export async function generateMetadata({
   const pattern = getPatternBySlug(slug);
   if (!pattern) return {};
 
-  const title = `${pattern.title} | AI Native Playbook`;
-  const description = pattern.description;
+  const title = `${pattern.title} — AI Business Framework | AI Native Playbook`;
+  const description = `${pattern.description.slice(0, 155)}…`;
 
   const { locale } = await params;
   const canonicalUrl = `${BASE_URL}/${locale}/patterns/${slug}`;
@@ -40,13 +40,22 @@ export async function generateMetadata({
   return {
     title,
     description,
+    keywords: [
+      pattern.title,
+      "AI architecture pattern",
+      "AI business automation",
+      pattern.sourceBook,
+      pattern.sourceAuthor,
+      "AI native playbook",
+      "AI agent framework",
+    ],
     openGraph: {
       title,
       description,
       url: canonicalUrl,
       type: "article",
       siteName: "AI Native Playbook",
-      images: [{ url: `${BASE_URL}/opengraph-image`, width: 1200, height: 630, alt: title }],
+      images: [{ url: `${BASE_URL}/${locale}/patterns/${slug}/opengraph-image`, width: 1200, height: 630, alt: title }],
     },
     twitter: {
       card: "summary_large_image",
@@ -55,6 +64,11 @@ export async function generateMetadata({
     },
     alternates: {
       canonical: canonicalUrl,
+      languages: {
+        en: `${BASE_URL}/en/patterns/${slug}`,
+        ja: `${BASE_URL}/ja/patterns/${slug}`,
+        "x-default": `${BASE_URL}/en/patterns/${slug}`,
+      },
     },
   };
 }
@@ -78,7 +92,8 @@ export default async function PatternPage({
     "@type": "HowTo",
     name: pattern.title,
     description: pattern.description,
-    url: `${BASE_URL}/patterns/${slug}`,
+    url: `${BASE_URL}/${locale}/patterns/${slug}`,
+    inLanguage: locale === "ja" ? "ja" : "en",
     step: pattern.keySteps.map((step, i) => ({
       "@type": "HowToStep",
       position: i + 1,
@@ -111,13 +126,13 @@ export default async function PatternPage({
         "@type": "ListItem",
         position: 2,
         name: "Patterns",
-        item: `${BASE_URL}/patterns`,
+        item: `${BASE_URL}/${locale}/patterns`,
       },
       {
         "@type": "ListItem",
         position: 3,
         name: pattern.title,
-        item: `${BASE_URL}/patterns/${slug}`,
+        item: `${BASE_URL}/${locale}/patterns/${slug}`,
       },
     ],
   };

--- a/src/app/[locale]/patterns/page.tsx
+++ b/src/app/[locale]/patterns/page.tsx
@@ -32,11 +32,17 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       "AI agent patterns",
     ],
     openGraph: {
-      title: "AI Architecture Patterns — Proven Business Frameworks Automated with AI | AI Native Playbook",
+      title: "AI Architecture Patterns — Proven Business Frameworks Automated with AI",
       description: "5 AI architecture patterns for business: Value Ladder, Mass Movement, Dream 100, Story Copy, Product Launch. Free to explore — runs on any AI.",
       url: canonicalUrl,
+      siteName: "AI Native Playbook",
       type: "website",
       images: [{ url: `${BASE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Architecture Patterns — AI Native Playbook" }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "AI Architecture Patterns — Proven Business Frameworks Automated with AI",
+      description: "5 AI architecture patterns for business: Value Ladder, Mass Movement, Dream 100, Story Copy, Product Launch. Free to explore — runs on any AI.",
     },
     alternates: {
       canonical: canonicalUrl,
@@ -70,14 +76,16 @@ export default async function PatternsPage({
     name: "AI Architecture Patterns — AI Native Playbook",
     description: "Proven business frameworks structured as AI architecture patterns — automated with AI for immediate execution",
     keywords: "AI architecture patterns, AI architect, AI native playbook, business automation AI",
-    url: `${BASE_URL}/patterns`,
+    url: `${BASE_URL}/${locale}/patterns`,
+    inLanguage: locale === "ja" ? "ja" : "en",
     mainEntity: {
       "@type": "ItemList",
+      numberOfItems: patterns.length,
       itemListElement: patterns.map((p, i) => ({
         "@type": "ListItem",
         position: i + 1,
         name: p.title,
-        url: `${BASE_URL}/patterns/${p.slug}`,
+        url: `${BASE_URL}/${locale}/patterns/${p.slug}`,
         description: p.description,
       })),
     },
@@ -88,7 +96,7 @@ export default async function PatternsPage({
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "AI Native Playbook", item: BASE_URL },
-      { "@type": "ListItem", position: 2, name: "Patterns", item: `${BASE_URL}/patterns` },
+      { "@type": "ListItem", position: 2, name: "Patterns", item: `${BASE_URL}/${locale}/patterns` },
     ],
   };
 


### PR DESCRIPTION
## Summary
- Add missing twitter card meta and siteName OG tag to `/en/patterns` list page
- Add keywords and `alternates.languages` to individual pattern (`[slug]`) pages for proper hreflang
- Fix all JSON-LD URLs (CollectionPage, ItemList, HowTo, BreadcrumbList) to include locale prefix (`/en/`, `/ja/`) instead of bare `/patterns/`
- Add `inLanguage` and `numberOfItems` properties to structured data schemas
- Use pattern-specific OG image URL on slug pages

## Test plan
- [ ] Verify `curl -s https://ai-native-playbook.com/en/patterns` returns correct meta/OG/twitter tags after deploy
- [ ] Validate JSON-LD with Google Rich Results Test for `/en/patterns` and `/en/patterns/value-ladder-automation`
- [ ] Check hreflang tags render for both `/en/` and `/ja/` variants on slug pages
- [ ] Confirm build passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keywords metadata for improved search engine visibility
  * Enabled language-specific page metadata for English, Japanese, and default language support

* **Improvements**
  * Enhanced metadata handling with locale-aware URLs and descriptions
  * Improved search engine optimization with structured data updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->