### PR TITLE
feat(patterns): slug-based unique OG images with AI Business Framework branding

### DIFF
--- a/src/app/[locale]/patterns/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/patterns/[slug]/opengraph-image.tsx
@@ -2,15 +2,40 @@ import { ImageResponse } from "next/og";
 import { getPatternBySlug } from "@/lib/patterns";
 
 export const runtime = "edge";
-export const alt = "AI Native Playbook Pattern";
+export const alt = "AI Business Framework Pattern";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default async function Image({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+const PALETTE = [
+  { primary: "#3b82f6", accent: "#1d4ed8", bg: "#0a1628" }, // blue
+  { primary: "#8b5cf6", accent: "#6d28d9", bg: "#120a28" }, // violet
+  { primary: "#06b6d4", accent: "#0891b2", bg: "#061a1e" }, // cyan
+  { primary: "#f59e0b", accent: "#d97706", bg: "#1a150a" }, // amber
+  { primary: "#10b981", accent: "#059669", bg: "#061a14" }, // emerald
+  { primary: "#ef4444", accent: "#dc2626", bg: "#1a0a0a" }, // red
+  { primary: "#ec4899", accent: "#db2777", bg: "#1a0a14" }, // pink
+  { primary: "#14b8a6", accent: "#0d9488", bg: "#0a1a18" }, // teal
+];
+
+function slugToColor(slug: string) {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = slug.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const idx = ((hash % PALETTE.length) + PALETTE.length) % PALETTE.length;
+  return PALETTE[idx];
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
   const { slug } = await params;
   const pattern = getPatternBySlug(slug);
   const title = pattern?.title || slug.replace(/-/g, " ");
   const subtitle = pattern?.subtitle || "";
+  const { primary, bg, accent } = slugToColor(slug);
 
   return new ImageResponse(
     (
@@ -18,7 +43,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         style={{
           width: "100%",
           height: "100%",
-          background: "linear-gradient(135deg, #060a14 0%, #0a0f1e 50%, #060a14 100%)",
+          background: `linear-gradient(135deg, #060a14 0%, ${bg} 50%, #060a14 100%)`,
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
@@ -34,7 +59,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
             left: 0,
             right: 0,
             height: "4px",
-            background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
+            background: `linear-gradient(90deg, ${accent}, ${primary}, ${accent})`,
           }}
         />
         <div
@@ -47,9 +72,9 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         >
           <div
             style={{
-              background: "rgba(226,183,20,0.1)",
-              border: "1px solid rgba(226,183,20,0.3)",
-              color: "#e2b714",
+              background: `${primary}18`,
+              border: `1px solid ${primary}50`,
+              color: primary,
               fontSize: "14px",
               fontWeight: "700",
               padding: "6px 16px",
@@ -57,12 +82,21 @@ export default async function Image({ params }: { params: Promise<{ slug: string
               letterSpacing: "1px",
             }}
           >
-            AI NATIVE PLAYBOOK — PATTERN
+            AI BUSINESS FRAMEWORK
+          </div>
+          <div
+            style={{
+              color: "#64748b",
+              fontSize: "14px",
+              fontWeight: "500",
+            }}
+          >
+            PATTERN
           </div>
         </div>
         <div
           style={{
-            fontSize: "44px",
+            fontSize: title.length > 40 ? "36px" : "44px",
             fontWeight: "800",
             color: "#f1f5f9",
             lineHeight: 1.2,
@@ -72,30 +106,48 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         >
           {title}
         </div>
-        <div
-          style={{
-            fontSize: "22px",
-            color: "#94a3b8",
-            lineHeight: 1.4,
-            maxWidth: "800px",
-          }}
-        >
-          {subtitle}
-        </div>
+        {subtitle && (
+          <div
+            style={{
+              fontSize: "22px",
+              color: "#94a3b8",
+              lineHeight: 1.4,
+              maxWidth: "800px",
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
         <div
           style={{
             position: "absolute",
             bottom: "30px",
+            left: "80px",
             right: "40px",
-            fontSize: "16px",
-            color: "#e2b714",
-            fontWeight: "600",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
-          ai-native-playbook.com
+          <div
+            style={{
+              width: "40px",
+              height: "3px",
+              background: `linear-gradient(90deg, ${primary}, transparent)`,
+            }}
+          />
+          <div
+            style={{
+              fontSize: "16px",
+              color: primary,
+              fontWeight: "600",
+            }}
+          >
+            ai-native-playbook.com
+          </div>
         </div>
       </div>
     ),
-    { ...size }
+    { ...size },
   );
 }


### PR DESCRIPTION
## Summary
- Enhances `/patterns/[slug]` OG images with slug-based unique color selection from an 8-color palette (blue, violet, cyan, amber, emerald, red, pink, teal)
- Adds "AI Business Framework" branding badge replacing the previous generic "AI NATIVE PLAYBOOK — PATTERN" label
- Dynamic font sizing for long pattern titles (>40 chars)

## Changes
- `src/app/[locale]/patterns/[slug]/opengraph-image.tsx`: Replaced single gold color scheme with deterministic slug-to-color mapping using hex palette, added branded badge layout

## Test plan
- [ ] Verify OG image renders for various pattern slugs (e.g., `/en/patterns/value-ladder-automation`)
- [ ] Confirm each slug produces a distinct color from the palette
- [ ] Check social media preview using og:image debugger tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)