### PR TITLE
feat(blog): dynamic OG image with category badge

### DIFF
--- a/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -5,10 +5,16 @@ export const alt = "AI Native Playbook Blog";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default async function Image({ params }: { params: { slug: string; locale: string } }) {
-  const post = getPostBySlug(params.slug);
-  const title = post?.title || params.slug.replace(/-/g, " ");
-  const desc = post?.description || "";
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  const title = post?.title || slug.replace(/-/g, " ");
+  const category = post?.category || "Blog";
+  const readTime = post?.readingTime || "";
 
   return new ImageResponse(
     (
@@ -25,6 +31,7 @@ export default async function Image({ params }: { params: { slug: string; locale
           position: "relative",
         }}
       >
+        {/* Top accent bar */}
         <div
           style={{
             position: "absolute",
@@ -35,51 +42,89 @@ export default async function Image({ params }: { params: { slug: string; locale
             background: "linear-gradient(90deg, #e2b714, #f0cc4a, #e2b714)",
           }}
         />
+
+        {/* Category badge + reading time */}
         <div
           style={{
-            color: "#e2b714",
-            fontSize: "16px",
-            fontWeight: "700",
-            marginBottom: "20px",
-            letterSpacing: "1px",
-            textTransform: "uppercase",
+            display: "flex",
+            gap: "12px",
+            marginBottom: "24px",
+            alignItems: "center",
           }}
         >
-          AI NATIVE PLAYBOOK — BLOG
+          <div
+            style={{
+              background: "rgba(226,183,20,0.15)",
+              border: "1px solid rgba(226,183,20,0.4)",
+              color: "#e2b714",
+              fontSize: "14px",
+              fontWeight: "700",
+              padding: "6px 18px",
+              borderRadius: "100px",
+              letterSpacing: "0.5px",
+              textTransform: "uppercase",
+            }}
+          >
+            {category}
+          </div>
+          {readTime ? (
+            <div
+              style={{
+                color: "#64748b",
+                fontSize: "14px",
+                fontWeight: "500",
+              }}
+            >
+              {readTime}
+            </div>
+          ) : null}
         </div>
+
+        {/* Title */}
         <div
           style={{
-            fontSize: "44px",
+            fontSize: title.length > 60 ? "36px" : "44px",
             fontWeight: "800",
             color: "#f1f5f9",
-            lineHeight: 1.2,
-            marginBottom: "20px",
-            maxWidth: "900px",
+            lineHeight: 1.25,
+            marginBottom: "24px",
+            maxWidth: "950px",
           }}
         >
           {title}
         </div>
-        <div
-          style={{
-            fontSize: "20px",
-            color: "#94a3b8",
-            lineHeight: 1.4,
-            maxWidth: "800px",
-          }}
-        >
-          {desc}
-        </div>
+
+        {/* Bottom branding */}
         <div
           style={{
             position: "absolute",
             bottom: "30px",
+            left: "80px",
             right: "40px",
-            fontSize: "16px",
-            color: "#e2b714",
-            fontWeight: "600",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
-          AI Native Playbook Series
+          <div
+            style={{
+              color: "#e2b714",
+              fontSize: "16px",
+              fontWeight: "700",
+              letterSpacing: "1px",
+            }}
+          >
+            AI NATIVE PLAYBOOK
+          </div>
+          <div
+            style={{
+              color: "#475569",
+              fontSize: "14px",
+              fontWeight: "500",
+            }}
+          >
+            ai-native-playbook.com/blog
+          </div>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Summary
- Blog post OG images now dynamically display the article title, category badge, reading time, and AI Native Playbook branding
- Follows the same visual pattern as existing product/pattern OG images (dark gradient, gold accent bar, pill badge)
- Fixes `params` type to use `Promise<>` (Next.js 15 convention)

## Test plan
- [ ] Verify OG image renders for a blog post: `/en/blog/<any-slug>/opengraph-image`
- [ ] Confirm category badge displays correctly
- [ ] Check long titles auto-shrink font size
- [ ] Compare visual consistency with `/en/products/<slug>/opengraph-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)