### PR TITLE
fix(ci): handle missing deploy hook secret in scheduled publish

### DIFF
--- a/.github/workflows/scheduled-publish.yml
+++ b/.github/workflows/scheduled-publish.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy Hook
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
         run: |
-          curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}"
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "::warning::VERCEL_DEPLOY_HOOK_URL secret is not set. Skipping deploy."
+            exit 0
+          fi
+          curl -sf -X POST "$DEPLOY_HOOK_URL"
           echo "Deploy hook triggered at $(date -u)"


### PR DESCRIPTION
## Summary
- The Scheduled Blog Publish CI was failing with exit code 3 because `VERCEL_DEPLOY_HOOK_URL` secret is empty/not set
- `curl -s -X POST ""` exits with code 3 when given an empty URL
- Fix: check if secret exists before calling curl, exit cleanly with warning if missing

## Root cause
The workflow uses `${{ secrets.VERCEL_DEPLOY_HOOK_URL }}` which resolves to empty string when the secret is not configured in the repository settings.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Set `VERCEL_DEPLOY_HOOK_URL` secret in repo settings for actual deploy functionality