### PR TITLE
feat(seo): optimize meta tags for legal pages

### DIFF
--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -9,20 +9,20 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const canonicalUrl = `${SITE_URL}/${locale}/privacy`;
 
   return {
-    title: "Privacy Policy — AI Native Playbook Series",
+    title: "Privacy Policy | AI Native Playbook — GDPR Compliant",
     description:
-      "Privacy Policy for AI Native Playbook Series by ai-architect. Learn how we collect, use, and protect your personal data in compliance with GDPR and international law.",
+      "Privacy Policy for AI Native Playbook Series. Learn how we protect your data with GDPR compliance, secure Paddle payments, and transparent cookie and analytics practices.",
     openGraph: {
-      title: "Privacy Policy — AI Native Playbook Series",
-      description: "Learn how we collect, use, and protect your personal data.",
+      title: "Privacy Policy | AI Native Playbook — GDPR Compliant",
+      description: "GDPR-compliant data protection, secure Paddle payments, and transparent privacy practices.",
       images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
     },
     alternates: {
       canonical: canonicalUrl,
     },
     robots: {
-      index: false,
-      follow: false,
+      index: true,
+      follow: true,
     },
   };
 }

--- a/src/app/[locale]/refund/page.tsx
+++ b/src/app/[locale]/refund/page.tsx
@@ -9,20 +9,20 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const canonicalUrl = `${SITE_URL}/${locale}/refund`;
 
   return {
-    title: "Refund Policy — AI Native Playbook Series",
+    title: "Refund Policy | 14-Day Money-Back — AI Native Playbook",
     description:
-      "Refund policy for AI Native Playbook Series digital products. Full refund available within 14 days of purchase if the product has not been downloaded. Download available for 30 days from purchase.",
+      "AI Native Playbook 14-day refund policy. Get a full refund within 14 days if not downloaded. Secure Paddle checkout, 30-day download window, and permanent content access.",
     openGraph: {
-      title: "Refund Policy — AI Native Playbook Series",
-      description: "Full refund within 14 days if not downloaded. Download available for 30 days.",
+      title: "Refund Policy | 14-Day Money-Back — AI Native Playbook",
+      description: "Full refund within 14 days if not downloaded. Secure checkout and permanent content access.",
       images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
     },
     alternates: {
       canonical: canonicalUrl,
     },
     robots: {
-      index: false,
-      follow: false,
+      index: true,
+      follow: true,
     },
   };
 }

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -9,20 +9,20 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const canonicalUrl = `${SITE_URL}/${locale}/terms`;
 
   return {
-    title: "Terms of Service — AI Native Playbook Series",
+    title: "Terms of Service | AI Native Playbook Digital Products",
     description:
-      "Terms of Service for AI Native Playbook Series by ai-architect. Digital product license, payment terms via Paddle, refund policy, and usage guidelines explained.",
+      "Read the Terms of Service for AI Native Playbook Series. Covers digital product license, secure Paddle payments, 14-day refund guarantee, and usage rights for AI guides.",
     openGraph: {
-      title: "Terms of Service — AI Native Playbook Series",
-      description: "Digital product license, payment terms, refund policy, and usage guidelines.",
+      title: "Terms of Service | AI Native Playbook Digital Products",
+      description: "Digital product license, secure Paddle payments, 14-day refund guarantee, and usage rights.",
       images: [{ url: `${SITE_URL}/opengraph-image`, width: 1200, height: 630, alt: "AI Native Playbook Series" }],
     },
     alternates: {
       canonical: canonicalUrl,
     },
     robots: {
-      index: false,
-      follow: false,
+      index: true,
+      follow: true,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Change `robots` from `noindex/nofollow` to `index/follow` on terms, privacy, and refund pages — legal pages serve as trust signals for search engines and potential buyers
- Optimize `<title>` tags within 60 characters with trust-building keywords (e.g., "14-Day Money-Back", "GDPR Compliant")
- Improve meta descriptions with purchase confidence signals (secure Paddle payments, refund guarantee, GDPR compliance)
- Update OpenGraph titles and descriptions to match

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Check each page renders correctly at `/en/terms`, `/en/privacy`, `/en/refund`
- [ ] Confirm meta tags in page source match new values
- [ ] Validate no legal text content was changed (meta only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)