### PR TITLE
fix(seo): www→non-www 301 redirect + explicit 307 download [AIN-48]

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,12 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
+        has: [{ type: "host", value: "www.ai-native-playbook.com" }],
+        destination: "https://ai-native-playbook.com/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
         has: [{ type: "host", value: "ai-driven-architect.com" }],
         destination: "https://ai-native-playbook.com/:path*",
         permanent: true,

--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -81,5 +81,5 @@ export async function GET(request: NextRequest) {
     console.error("[download] log failed:", err)
   );
 
-  return NextResponse.redirect(product.url);
+  return NextResponse.redirect(product.url, 307);
 }


### PR DESCRIPTION
## Summary
- **www→non-www 301 redirect**: `www.ai-native-playbook.com` → `ai-native-playbook.com`으로 영구 리다이렉트 추가. 도메인 통일로 link equity 분산 방지.
- **Download API 307 명시화**: `NextResponse.redirect(url)` → `NextResponse.redirect(url, 307)` — 임시 다운로드 URL임을 코드에서 명확히 표현.

## 302→301 감사 결과
| 경로 | 현재 상태 | 조치 |
|------|----------|------|
| `www.ai-native-playbook.com/*` | Vercel 기본(302 가능) | **301로 명시 추가** ✅ |
| `/ko`, `/ko/*` → `/` | 이미 301 | 변경 없음 |
| `/api/download` → R2 URL | 307 (기본) | **307 명시화** (임시 URL이므로 정확) |
| next-intl locale 감지 `/` → `/en` | 307 | 변경 없음 (동적 로케일 감지이므로 정확) |

## sameAs 소셜 채널
코드베이스 전체 검색 결과 브랜드 전용 소셜 미디어 계정(Twitter/X, LinkedIn 페이지 등)이 없음.
이슈 조건 "있다면 추가"에 따라 현재 N/A. 소셜 계정 생성 시 추가 필요.

## Test plan
- [x] `next build` 성공
- [x] `vitest run download-api.test.ts` 전부 통과 (10/10)
- [x] 기존 테스트 실패는 Brevo/Resend 설정 관련 (본 변경과 무관)
- [ ] Vercel Preview에서 `www.ai-native-playbook.com` 리다이렉트 확인 (배포 후)

Closes AIN-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)