### PR TITLE
feat: FAQPage JSON-LD for blog posts (AIN-53)

### DIFF
--- a/content/blog/ai-sales-funnel-guide-2026.md
+++ b/content/blog/ai-sales-funnel-guide-2026.md
@@ -7,6 +7,17 @@ author: "AI Native Playbook"
 tags: ["AI sales funnel", "automated sales funnel", "AI funnel builder", "sales automation", "AI marketing"]
 category: "AI Marketing"
 readingTime: "10 min read"
+faq:
+  - q: "How much does it cost to build an AI sales funnel?"
+    a: "The core stack costs $40-80/month: an AI writing tool ($20/month), an email platform (free tier to $30/month), and a page builder ($0-30/month). No designer, copywriter, or marketing agency required. Most solopreneurs build their first funnel for under $100 total including the first month of tools."
+  - q: "How long does it take to see results from an AI sales funnel?"
+    a: "A functional funnel can be built in 30 days following the plan in this guide. First revenue typically appears within 2-4 weeks of launch if you have an existing audience. Cold traffic funnels take 4-8 weeks to optimize. The key is launching version one quickly and improving based on data, not waiting for perfection."
+  - q: "Do I need coding skills to build an AI-powered funnel?"
+    a: "No. Modern page builders, email platforms, and AI writing tools are all designed for non-technical users. The entire funnel described in this guide can be built using drag-and-drop interfaces and AI-generated copy. If you can write an email and use a web browser, you can build this funnel."
+  - q: "What is the best AI tool for writing funnel copy?"
+    a: "Claude and ChatGPT are the leading options. Both can generate landing page copy, email sequences, and sales page sections when given proper framework prompts. The key differentiator is not the tool but the framework you use — the Russell Brunson and Jeff Walker frameworks referenced in this guide produce consistently higher-converting copy than generic prompts."
+  - q: "Can an AI funnel work for physical products or only digital?"
+    a: "AI funnels work for both, but the economics are strongest for digital products and services where margins are 70%+ and delivery is automated. Physical product funnels benefit from AI-generated copy and email sequences but still require fulfillment logistics. The funnel structure described here applies to any product type."
 ---
 
 The average sales funnel built in 2020 required a copywriter, a designer, an email marketer, and a paid ads specialist. In 2026, a solopreneur with the right AI system can build the same funnel in a weekend — and outperform the old four-person team.

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -15,6 +15,7 @@ import BlogRelatedInline from "@/components/BlogRelatedInline";
 import EmailCapture from "@/components/EmailCapture";
 import BlogBottomCTA from "@/components/BlogBottomCTA";
 import { splitContentThreeWay } from "@/lib/blog-content-utils";
+import { buildFaqJsonLd } from "@/lib/faq-utils";
 
 export const revalidate = 60; // 60초마다 재검증 — 예약 시각 도래 시 자동 공개
 
@@ -189,6 +190,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     ],
   };
 
+  const pageUrl = locale === "en" ? `${siteUrl}/en/blog/${slug}` : `${siteUrl}/${locale}/blog/${slug}`;
+  const faqJsonLd = post.faq ? buildFaqJsonLd(post.faq, pageUrl, locale) : null;
+
   function escapeJsonLd(json: string): string {
     return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
   }
@@ -203,6 +207,12 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(breadcrumbJsonLd)) }}
       />
+      {faqJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: escapeJsonLd(JSON.stringify(faqJsonLd)) }}
+        />
+      )}
     <div className="max-w-3xl mx-auto px-4 py-16">
       <div className="mb-8">
         <Link href="/blog" className="text-gold hover:underline text-sm">← Back to Blog</Link>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import readingTime from "reading-time";
+import { type FaqItem, parseFaqFromContent } from "./faq-utils";
 
 const BLOG_DIR = path.join(process.cwd(), "content/blog");
 
@@ -24,6 +25,8 @@ export interface BlogPost {
   noindex?: boolean;
   /** 최종 수정일. frontmatter `updated` 필드. 미설정 시 date와 동일 */
   updated?: string;
+  /** FAQ 데이터. frontmatter `faq` 필드 또는 콘텐츠 `## FAQ` 섹션에서 자동 파싱 */
+  faq?: FaqItem[];
 }
 
 /**
@@ -94,6 +97,9 @@ export function getPostBySlug(slug: string): BlogPost | null {
   const { data, content } = matter(raw);
   const stats = readingTime(raw);
 
+  const faqFromFrontmatter = Array.isArray(data.faq) ? data.faq as FaqItem[] : undefined;
+  const faq = faqFromFrontmatter ?? (parseFaqFromContent(content) || undefined);
+
   const post = {
     slug,
     title: data.title ?? slug,
@@ -108,6 +114,7 @@ export function getPostBySlug(slug: string): BlogPost | null {
     scheduledAt: data.scheduledAt as string | undefined,
     noindex: data.noindex as boolean | undefined,
     updated: (data.updated as string | undefined) ?? undefined,
+    faq: faq.length > 0 ? faq : undefined,
   };
 
   // 비공개 포스트 직접 접근 차단

--- a/src/lib/faq-utils.ts
+++ b/src/lib/faq-utils.ts
@@ -1,0 +1,58 @@
+export interface FaqItem {
+  q: string;
+  a: string;
+}
+
+/**
+ * Parse FAQ Q&A pairs from markdown content.
+ * Looks for a `## FAQ` section with `### Question` subheadings.
+ */
+export function parseFaqFromContent(content: string): FaqItem[] {
+  const faqSectionMatch = content.match(/^## FAQ\s*$/m);
+  if (!faqSectionMatch || faqSectionMatch.index === undefined) return [];
+
+  const faqStart = faqSectionMatch.index + faqSectionMatch[0].length;
+  const nextH2 = content.slice(faqStart).match(/^## /m);
+  const faqSection = nextH2 && nextH2.index !== undefined
+    ? content.slice(faqStart, faqStart + nextH2.index)
+    : content.slice(faqStart);
+
+  const items: FaqItem[] = [];
+  const questionBlocks = faqSection.split(/^### /m).slice(1);
+
+  for (const block of questionBlocks) {
+    const lines = block.trim().split("\n");
+    const question = lines[0].trim().replace(/\?$/, "?");
+    const answer = lines
+      .slice(1)
+      .join("\n")
+      .trim();
+
+    if (question && answer) {
+      items.push({ q: question, a: answer });
+    }
+  }
+
+  return items;
+}
+
+export function buildFaqJsonLd(
+  faqs: FaqItem[],
+  pageUrl: string,
+  locale: string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    url: pageUrl,
+    inLanguage: locale === "ko" ? "ko-KR" : locale === "ja" ? "ja-JP" : "en-US",
+    mainEntity: faqs.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- FAQPage JSON-LD 구조화 데이터를 블로그 포스트에 자동 추가
- 콘텐츠 내 `## FAQ / ### Q?` 패턴 자동 파싱 + frontmatter `faq` 필드 지원 (이중 소싱)
- 기존 BlogPosting + BreadcrumbList schema와 병렬 배치 (한 페이지에 3개 JSON-LD)
- 3개 포스트에 적용 완료:
  - `how-to-start-ai-native-business-2026` (7 FAQs, 콘텐츠 파싱)
  - `one-person-business-with-ai-2026` (7 FAQs, 콘텐츠 파싱)
  - `ai-sales-funnel-guide-2026` (5 FAQs, frontmatter)

## Changes
- `src/lib/faq-utils.ts` — FAQ 파싱 + JSON-LD 빌더 유틸리티 (신규)
- `src/lib/blog.ts` — BlogPost 인터페이스에 `faq?` 필드 추가, getPostBySlug에서 자동 파싱
- `src/app/[locale]/blog/[slug]/page.tsx` — FAQPage JSON-LD 스크립트 태그 조건부 삽입
- `content/blog/ai-sales-funnel-guide-2026.md` — frontmatter `faq` 필드 추가

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] Next.js 빌드 성공
- [x] FAQ 콘텐츠 파싱 검증 (2개 포스트, 각 7개 Q&A)
- [x] FAQ frontmatter 파싱 검증 (1개 포스트, 5개 Q&A)
- [x] FAQ 없는 포스트에서 JSON-LD 미생성 확인
- [ ] Google Rich Results Test 검증 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now support customizable FAQ sections with Q&A pairs
  * FAQ data automatically generates schema markup for improved search engine visibility and discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->