### PR TITLE
feat(blog): Blog #1–#3 cross-linking + CTA unification (AIN-70)

### DIFF
--- a/content/blog/ai-automation-playbook-solopreneurs.md
+++ b/content/blog/ai-automation-playbook-solopreneurs.md
@@ -102,6 +102,8 @@ Content is the highest-leverage starting point because it drives traffic, leads,
 
 Once this pipeline is running, you produce 8–12 pieces of content per month with under 3 hours of your time.
 
+For the full operating system blueprint — four AI agents, six build steps, and a practical weekly workflow — read [How to Run a One-Person Business with AI Agents](/en/blog/one-person-business-ai-agents-guide).
+
 ---
 
 ## Phase 3: Automate Your Marketing Funnel
@@ -196,15 +198,9 @@ Each is deployed as a reusable AI agent skill set, not a static prompt.
 
 An AI automation playbook isn't built overnight, but it starts with one decision: you are going to be the **architect**, not the executor.
 
-The [AI Native Playbook Series](https://ai-native-playbook.com) gives you six frameworks pre-built as AI agent skill sets, ready to deploy as your automation OS.
+**Start here:** [Get the Free AI Starter Guide](/en/free-guide) — the exact system prompts and frameworks to put AI to work in your business today.
 
-**Get the free implementation guide** — join the email list for the step-by-step deployment checklist and new framework releases:
-
-→ [Subscribe for the AI Native Playbook updates](https://ai-native-playbook.com/#email-signup)
-
-Or explore the full product:
-
-→ [AI Native Playbook Series](https://ai-native-playbook.com)
+**Go deeper:** [Explore the AI Native Playbook Series](/en/products) — six proven frameworks deployed as AI agent skill sets for your business.
 
 ---
 

--- a/content/blog/ai-native-business-framework.md
+++ b/content/blog/ai-native-business-framework.md
@@ -151,7 +151,7 @@ The framework is most powerful when applied systematically, but you don't have t
 
 **Phase 2 — Full Stack:** Design your human oversight architecture. Define exactly which decisions escalate to you and which run autonomously. Set your weekly review cadence for system performance.
 
-For the step-by-step automation playbook, read [The AI Automation Playbook for Solopreneurs](/en/blog/ai-automation-playbook-solopreneurs).
+For the step-by-step automation playbook, read [The AI Automation Playbook for Solopreneurs](/en/blog/ai-automation-playbook-solopreneurs). If you want to see how AI agents map to each of these phases in a real one-person business, read [How to Run a One-Person Business with AI Agents](/en/blog/one-person-business-ai-agents-guide).
 
 The ceiling changes when you operate this way. You're no longer trading time for output — you're designing systems that produce output while you focus on what actually moves the business forward.
 
@@ -185,9 +185,9 @@ An AI user uses AI tools to complete tasks — they prompt, review, and execute.
 
 This framework is at the core of the methodology we teach at AI Native Playbook — not just AI tools, but the full operating model for running a business built on AI from the ground up.
 
-**Start here:** [Join the AI Native Playbook email list](/en/free-guide) — each week, one system, one principle, one real example from building an AI native business, applied.
+**Start here:** [Get the Free AI Starter Guide](/en/free-guide) — the exact system prompts and frameworks to put AI to work in your business today.
 
-**Go deeper:** [Explore the AI Native Playbook](/en/products) — the complete methodology for building and operating an AI native business.
+**Go deeper:** [Explore the AI Native Playbook Series](/en/products) — six proven frameworks deployed as AI agent skill sets for your business.
 
 ---
 

--- a/content/blog/one-person-business-ai-agents-guide.md
+++ b/content/blog/one-person-business-ai-agents-guide.md
@@ -255,11 +255,6 @@ The AI OS model works best for: digital product businesses (courses, playbooks, 
 
 The one-person AI business OS is not a future concept. It's a practical system you can build today with available tools and proven frameworks.
 
-The [AI Native Playbook Series](https://ai-native-playbook.com) provides six automation frameworks pre-built as AI agent skill sets — the fastest path to a running AI OS for your business.
+**Start here:** [Get the Free AI Starter Guide](/en/free-guide) — the exact system prompts and frameworks to put AI to work in your business today.
 
-**[Get early access to the AI Native Playbook Series](/en/free-guide)**
-
-Ready to go deeper on the framework? Explore the full series:
-- [The AI Native Business Framework](/en/blog/ai-native-business-framework) — the operating model
-- [The AI Automation Playbook for Solopreneurs](/en/blog/ai-automation-playbook-solopreneurs) — the build sequence
-- [How to Run a One-Person Business with AI Agents](/en/blog/one-person-business-ai-agents-guide) — the AI OS guide (you are here)
+**Go deeper:** [Explore the AI Native Playbook Series](/en/products) — six proven frameworks deployed as AI agent skill sets for your business.


### PR DESCRIPTION
## Summary

- Blog #1 (AI Native Business Framework), #2 (AI Automation Playbook), #3 (One-Person Business AI Agents Guide) 간 인라인 크로스링크 강화
- Blog #1에 #3 인라인 참조 추가, Blog #2에 #3 인라인 참조 추가
- 3편의 CTA를 통일: `/en/free-guide` (Free AI Starter Guide) + `/en/products` (AI Native Playbook Series)
- Blog #2의 외부 URL (`https://ai-native-playbook.com/#email-signup`) → 내부 경로로 수정

## Cross-Link Matrix (After)

| From / To | Blog #1 | Blog #2 | Blog #3 |
|---|---|---|---|
| Blog #1 | — | ✅ inline + related | ✅ inline (NEW) + related |
| Blog #2 | ✅ inline + related | — | ✅ inline (NEW) + related |
| Blog #3 | ✅ inline | ✅ inline | — |

## Test plan

- [x] `next build` passes
- [ ] Verify 3 blog posts render correctly on dev server
- [ ] Verify all internal links navigate correctly
- [ ] Verify sitemap includes all 3 posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated calls-to-action across blog articles linking to the Free AI Starter Guide and AI Native Playbook Series.
  * Added cross-references between related AI automation and business framework content for improved navigation.
  * Expanded FAQ section with new guidance on founder availability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->